### PR TITLE
Implement portfolio CLI and core services

### DIFF
--- a/PRICING.md
+++ b/PRICING.md
@@ -1,0 +1,27 @@
+# Pricing Providers & Cache
+
+The portfolio tool resolves last-traded prices through a provider abstraction defined in `portfolio_tool.core.pricing`. Two providers are bundled:
+
+- **Yahoo Finance (yfinance)** – default provider using the community yfinance package.
+- **YahooQuery** – optional alternative using the yahooquery client.
+
+> ⚠️ Both integrations call unofficial Yahoo Finance endpoints which may change without notice. The application remains functional offline by falling back to cached values stored in SQLite.
+
+## Cache Behaviour
+
+- Quotes are cached in the `price_cache` table with a configurable TTL (`price_ttl_minutes`, default 15 minutes).
+- When a request arrives:
+  - If a cached quote is fresh (`ttl_expires_at` in the future), it is returned without a network call.
+  - If the cache is stale and `offline_mode = false`, the provider is queried and the cache is refreshed.
+  - If the provider fails or `offline_mode = true`, the most recent cached quote is returned and marked `is_stale = true`.
+- The `price-refresh` CLI command forces a refresh for specific tickers.
+
+## Switching Providers
+
+Update `~/.portfolio_tool/config.toml` (or use `portfolio config set`) to change provider:
+
+```toml
+price_provider = "yahooquery"
+```
+
+Any provider implementing the `PriceProvider` protocol can be registered in `portfolio_tool.__main__.py`.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,48 @@
-# StockTrak
+# Portfolio Tool
 
-Version 1.0.0
+A command-line portfolio tracker for ASX and US equities with Australian CGT-aware lot management, price caching, and actionable reminders.
+
+## Quickstart
+
+```bash
+# Install dependencies (preferably inside a virtual environment)
+pip install -e .[dev]
+
+# Initialise the SQLite database
+default_config_dir=~/.portfolio_tool
+mkdir -p "$default_config_dir"
+
+# Add your first trade
+portfolio add-trade
+
+# View current positions
+portfolio positions
+```
+
+All application data (configuration, SQLite database, and markdown exports) lives under `~/.portfolio_tool` by default. Override the location via the `PORTFOLIO_TOOL_HOME` environment variable or by passing `--config` to any command.
+
+## Features
+
+- Manual trade entry (buy or sell) with timezone-aware timestamps, fees, and optional notes.
+- Lot tracking with FIFO, HIFO, and Specific-ID disposal matching.
+- Australian CGT discount eligibility tracking per lot.
+- Price fetching via Yahoo Finance APIs with SQLite-backed caching and offline fallbacks.
+- Actionable alerts for CGT windows, portfolio overweight/concentration breaches, drawdowns, and stale notes.
+- Rich CLI tables plus Markdown export for reports and audit logs.
+- Configurable defaults using `~/.portfolio_tool/config.toml`.
+
+## Testing
+
+```bash
+pytest
+```
+
+The test suite covers lot matching strategies, CGT discount windows, brokerage allocation, cached pricing behaviour, actionable rules, and golden-file markdown exports.
+
+## Configuration
+
+`portfolio config show` displays the active configuration. Update individual values with `portfolio config set KEY VALUE` (e.g. `portfolio config set price_ttl_minutes 30`). Nested keys are specified with dot notation, such as `portfolio config set target_weights.CSL 0.15`.
+
+## Documentation
+
+See [PRICING.md](PRICING.md) for provider and caching specifics.

--- a/portfolio_tool/__main__.py
+++ b/portfolio_tool/__main__.py
@@ -1,0 +1,439 @@
+from __future__ import annotations
+
+import datetime as dt
+import tomllib
+from decimal import Decimal
+from pathlib import Path
+from typing import Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+from zoneinfo import ZoneInfo
+
+from portfolio_tool.config import Config, ensure_app_dirs, load_config
+from portfolio_tool.core.cgt import cgt_threshold
+from portfolio_tool.core.lots import apply_disposal, match_disposal
+from portfolio_tool.core.pricing import PriceService
+from portfolio_tool.core.reports import (
+    build_audit_log,
+    build_cgt_calendar,
+    build_lots,
+    build_positions,
+    build_pnl,
+)
+from portfolio_tool.core.rules import generate_all_actionables
+from portfolio_tool.core.trades import TradeInput, record_trade
+from portfolio_tool.data import models, repo
+from portfolio_tool.data.repo import Database
+from portfolio_tool.providers.yfinance_provider import YFinanceProvider
+from portfolio_tool.providers.yahooquery_provider import YahooQueryProvider
+from portfolio_tool.reports import md_renderer, tables
+from sqlalchemy import select
+
+console = Console()
+app = typer.Typer(help="Portfolio tracker")
+config_app = typer.Typer(help="Manage configuration")
+app.add_typer(config_app, name="config")
+
+
+def get_provider(cfg: Config):
+    if cfg.price_provider == "yahooquery":
+        return YahooQueryProvider()
+    return YFinanceProvider()
+
+
+@app.callback()
+def main(
+    ctx: typer.Context,
+    config: Optional[Path] = typer.Option(None, "--config", help="Path to config.toml"),
+):
+    cfg = load_config(config)
+    ensure_app_dirs(cfg)
+    database = Database(cfg)
+    database.create_all()
+    ctx.obj = {"cfg": cfg, "db": database, "pricing": PriceService(cfg, get_provider(cfg))}
+
+
+def _prompt_decimal(prompt: str, default: Optional[Decimal] = None) -> Decimal:
+    default_str = str(default) if default is not None else None
+    value = typer.prompt(prompt, default=default_str)
+    return Decimal(value)
+
+
+def _prompt_datetime(prompt: str, cfg: Config, default: Optional[dt.datetime] = None) -> dt.datetime:
+    if default is None:
+        default = dt.datetime.now(ZoneInfo(cfg.timezone))
+    value = typer.prompt(prompt, default=default.isoformat())
+    dt_value = dt.datetime.fromisoformat(value)
+    if dt_value.tzinfo is None:
+        dt_value = dt_value.replace(tzinfo=ZoneInfo(cfg.timezone))
+    return dt_value.astimezone(dt.timezone.utc)
+
+
+@app.command()
+def add_trade(
+    ctx: typer.Context,
+    side: Optional[str] = typer.Option(None, help="BUY or SELL"),
+    symbol: Optional[str] = typer.Option(None, help="Ticker symbol"),
+    method: Optional[str] = typer.Option(None, help="Lot matching override"),
+):
+    cfg: Config = ctx.obj["cfg"]
+    db: Database = ctx.obj["db"]
+    if side is None:
+        side = typer.prompt("Side (BUY/SELL)")
+    side = side.upper()
+    if side not in {"BUY", "SELL"}:
+        raise typer.BadParameter("Side must be BUY or SELL")
+    if symbol is None:
+        symbol = typer.prompt("Symbol").upper()
+    else:
+        symbol = symbol.upper()
+    trade_dt = _prompt_datetime("Trade datetime (ISO)", cfg)
+    qty = _prompt_decimal("Quantity")
+    price = _prompt_decimal("Price")
+    fees = _prompt_decimal("Fees", Decimal("0"))
+    exchange = typer.prompt("Exchange", default="") or None
+    note = typer.prompt("Note", default="") or None
+
+    match_method = (method or cfg.lot_matching).upper()
+    specific_ids = None
+    if side == "SELL" and match_method == "SPECIFIC_ID":
+        with db.session_scope() as session:
+            lots = repo.list_open_lots(session, symbol)
+        if not lots:
+            raise typer.BadParameter("No lots available to match SELL")
+        default_ids = ",".join(str(l.id) for l in lots)
+        id_input = typer.prompt("Lot IDs (comma separated)", default=default_ids)
+        specific_ids = [int(part.strip()) for part in id_input.split(",") if part.strip()]
+
+    trade_input = TradeInput(
+        side=side,
+        symbol=symbol,
+        dt=trade_dt,
+        qty=qty,
+        price=price,
+        fees=fees,
+        exchange=exchange,
+        note=note,
+    )
+
+    try:
+        with db.session_scope() as session:
+            trade = record_trade(
+                session,
+                cfg,
+                trade_input,
+                match_method=match_method,
+                specific_ids=specific_ids,
+            )
+        console.print(f"Created {side} trade {trade.id} for {symbol}")
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+
+@app.command()
+def edit_trade(ctx: typer.Context, trade_id: int):
+    cfg: Config = ctx.obj["cfg"]
+    db: Database = ctx.obj["db"]
+    with db.session_scope() as session:
+        trade = session.get(models.Trade, trade_id)
+        if not trade:
+            raise typer.BadParameter("Trade not found")
+        note = typer.prompt("Note", default=trade.note or "")
+        updates = {"note": note}
+        repo.update_trade(session, trade_id, updates)
+        console.print(f"Updated trade {trade_id}")
+
+
+@app.command()
+def delete_trade(ctx: typer.Context, trade_id: int):
+    db: Database = ctx.obj["db"]
+    with db.session_scope() as session:
+        repo.delete_trade(session, trade_id)
+        console.print(f"Deleted trade {trade_id}")
+
+
+@app.command()
+def positions(
+    ctx: typer.Context,
+    export_md: Optional[Path] = typer.Option(None, "--export", help="Export markdown path"),
+):
+    cfg: Config = ctx.obj["cfg"]
+    db: Database = ctx.obj["db"]
+    pricing: PriceService = ctx.obj["pricing"]
+    with db.session_scope() as session:
+        rows = build_positions(session, cfg, pricing)
+        table = tables.positions_table(rows)
+        console.print(table)
+        if export_md:
+            export_md.parent.mkdir(parents=True, exist_ok=True)
+            export_md.write_text(md_renderer.positions_markdown(rows), encoding="utf-8")
+            console.print(f"Exported markdown to {export_md}")
+
+
+@app.command()
+def lots(
+    ctx: typer.Context,
+    symbol: str,
+    export_md: Optional[Path] = typer.Option(None, "--export", help="Export markdown path"),
+):
+    db: Database = ctx.obj["db"]
+    with db.session_scope() as session:
+        rows = build_lots(session, symbol)
+        table = tables.lots_table(rows)
+        console.print(table)
+        if export_md:
+            export_md.parent.mkdir(parents=True, exist_ok=True)
+            export_md.write_text(md_renderer.lots_markdown(rows), encoding="utf-8")
+            console.print(f"Exported markdown to {export_md}")
+
+
+@app.command()
+def cgt_calendar(
+    ctx: typer.Context,
+    window: Optional[int] = typer.Option(None, "--window", help="Days window"),
+    export_md: Optional[Path] = typer.Option(None, "--export", help="Export markdown path"),
+):
+    cfg: Config = ctx.obj["cfg"]
+    db: Database = ctx.obj["db"]
+    horizon = window or cfg.rule_thresholds.cgt_window_days
+    with db.session_scope() as session:
+        rows = build_cgt_calendar(session, cfg, horizon)
+        table = tables.lots_table(rows)
+        table.title = "CGT Calendar"
+        console.print(table)
+        if export_md:
+            export_md.parent.mkdir(parents=True, exist_ok=True)
+            export_md.write_text(md_renderer.lots_markdown(rows), encoding="utf-8")
+            console.print(f"Exported markdown to {export_md}")
+
+
+@app.command()
+def pnl(
+    ctx: typer.Context,
+    realised: bool = typer.Option(False, "--realised", help="Show realised PnL"),
+    unrealised: bool = typer.Option(False, "--unrealised", help="Show unrealised PnL"),
+):
+    if realised and unrealised:
+        raise typer.BadParameter("Choose either realised or unrealised")
+    realised = realised or not unrealised
+    db: Database = ctx.obj["db"]
+    with db.session_scope() as session:
+        rows = build_pnl(session, realised=realised)
+        table = Table(title="Realised PnL" if realised else "Unrealised PnL")
+        if realised:
+            table.add_column("Symbol")
+            table.add_column("Lot ID")
+            table.add_column("Qty")
+            table.add_column("Gain/Loss")
+            table.add_column("Discount Eligible")
+            for row in rows:
+                table.add_row(
+                    row["symbol"],
+                    str(row["lot_id"]),
+                    f"{row['qty']:.4f}",
+                    f"{row['gain_loss']:.2f}",
+                    "Yes" if row["eligible_discount"] else "No",
+                )
+        else:
+            table.add_column("Symbol")
+            table.add_column("Lot ID")
+            table.add_column("Qty")
+            table.add_column("Cost Base")
+            table.add_column("CGT Threshold")
+            for row in rows:
+                table.add_row(
+                    row["symbol"],
+                    str(row["lot_id"]),
+                    f"{row['qty']:.4f}",
+                    f"{row['cost_base']:.2f}",
+                    row["threshold_date"].isoformat(),
+                )
+        console.print(table)
+
+
+@app.command()
+def audit(ctx: typer.Context):
+    db: Database = ctx.obj["db"]
+    with db.session_scope() as session:
+        rows = build_audit_log(session)
+        table = Table(title="Audit Log")
+        table.add_column("ID")
+        table.add_column("Action")
+        table.add_column("Entity")
+        table.add_column("Entity ID")
+        table.add_column("Timestamp")
+        table.add_column("Payload")
+        for row in rows:
+            table.add_row(
+                str(row["id"]),
+                row["action"],
+                row["entity"],
+                str(row["entity_id"]),
+                row["created_at"].isoformat() if row["created_at"] else "",
+                row["payload"] or "",
+            )
+        console.print(table)
+
+
+@app.command()
+def price_refresh(ctx: typer.Context, symbols: list[str]):
+    if not symbols:
+        raise typer.BadParameter("Provide at least one symbol")
+    cfg: Config = ctx.obj["cfg"]
+    db: Database = ctx.obj["db"]
+    pricing: PriceService = ctx.obj["pricing"]
+    with db.session_scope() as session:
+        quotes = pricing.get_quotes(session, [s.upper() for s in symbols])
+        table = Table(title="Price Refresh")
+        table.add_column("Symbol")
+        table.add_column("Price")
+        table.add_column("Currency")
+        table.add_column("As of")
+        for symbol in symbols:
+            quote = quotes.get(symbol.upper())
+            if quote:
+                table.add_row(
+                    quote.symbol,
+                    f"{quote.price:.2f}",
+                    quote.currency,
+                    quote.asof.isoformat(),
+                )
+        console.print(table)
+
+
+@app.command()
+def actionables(
+    ctx: typer.Context,
+    complete: Optional[int] = typer.Option(None, "--complete", help="Complete actionable ID"),
+    snooze: Optional[int] = typer.Option(None, "--snooze", help="Snooze actionable ID"),
+    days: int = typer.Option(7, help="Snooze days"),
+):
+    cfg: Config = ctx.obj["cfg"]
+    db: Database = ctx.obj["db"]
+    with db.session_scope() as session:
+        if complete:
+            actionable = session.get(models.Actionable, complete)
+            if not actionable:
+                raise typer.BadParameter("Actionable not found")
+            actionable.status = "completed"
+            console.print(f"Completed actionable {complete}")
+            return
+        if snooze:
+            actionable = session.get(models.Actionable, snooze)
+            if not actionable:
+                raise typer.BadParameter("Actionable not found")
+            actionable.due_at = dt.datetime.now(dt.timezone.utc) + dt.timedelta(days=days)
+            console.print(f"Snoozed actionable {snooze} for {days} days")
+            return
+        positions_rows = build_positions(session, cfg, ctx.obj["pricing"])
+        all_lots = session.scalars(select(models.Lot)).all()
+        generated = generate_all_actionables(session, cfg, positions_rows, all_lots)
+        existing = repo.list_actionables(session)
+        existing_keys = {(a.type, a.message) for a in existing}
+        for item in generated:
+            key = (item.type, item.message)
+            if key not in existing_keys:
+                repo.create_actionable(
+                    session,
+                    type=item.type,
+                    symbol=item.symbol,
+                    message=item.message,
+                    status="open",
+                    due_at=item.due_at,
+                )
+        session.flush()
+        open_items = repo.list_actionables(session)
+        table = Table(title="Actionables")
+        table.add_column("ID")
+        table.add_column("Type")
+        table.add_column("Symbol")
+        table.add_column("Message")
+        table.add_column("Due")
+        table.add_column("Status")
+        for item in open_items:
+            table.add_row(
+                str(item.id),
+                item.type,
+                item.symbol or "",
+                item.message,
+                item.due_at.isoformat() if item.due_at else "",
+                item.status,
+            )
+        console.print(table)
+
+
+def _load_config_raw(path: Path) -> dict:
+    if path.exists():
+        with path.open("rb") as fh:
+            return tomllib.load(fh)
+    return {}
+
+
+def _format_toml_value(value: object) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, Decimal):
+        return str(value)
+    return f'"{value}"'
+
+
+def _dump_toml(data: dict, prefix: Optional[str] = None) -> list[str]:
+    lines: list[str] = []
+    for key, value in data.items():
+        if isinstance(value, dict):
+            continue
+        lines.append(f"{key} = {_format_toml_value(value)}")
+    for key, value in data.items():
+        if isinstance(value, dict):
+            section = key if prefix is None else f"{prefix}.{key}"
+            lines.append(f"[{section}]")
+            lines.extend(_dump_toml(value, section))
+    return lines
+
+
+def _set_config_value(data: dict, key: str, value: object) -> None:
+    parts = key.split(".")
+    current = data
+    for part in parts[:-1]:
+        current = current.setdefault(part, {})
+    current[parts[-1]] = value
+
+
+def _parse_value(value: str) -> object:
+    lowered = value.lower()
+    if lowered in {"true", "false"}:
+        return lowered == "true"
+    try:
+        if "." in value:
+            return float(value)
+        return int(value)
+    except ValueError:
+        try:
+            return Decimal(value)
+        except Exception:
+            return value
+
+
+@config_app.command("show")
+def config_show(ctx: typer.Context):
+    console.print(ctx.obj["cfg"])
+
+
+@config_app.command("set")
+def config_set(ctx: typer.Context, key: str, value: str):
+    cfg: Config = ctx.obj["cfg"]
+    config_path = cfg.config_dir / "config.toml"
+    cfg.config_dir.mkdir(parents=True, exist_ok=True)
+    data = _load_config_raw(config_path)
+    _set_config_value(data, key, _parse_value(value))
+    lines = _dump_toml(data)
+    config_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    console.print(f"Updated {config_path}")
+
+
+if __name__ == "__main__":
+    app()

--- a/portfolio_tool/config.py
+++ b/portfolio_tool/config.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import tomllib
+
+DEFAULT_CONFIG_DIR = Path(os.environ.get("PORTFOLIO_TOOL_HOME", Path.home() / ".portfolio_tool"))
+DEFAULT_CONFIG_PATH = DEFAULT_CONFIG_DIR / "config.toml"
+DEFAULT_DB_PATH = DEFAULT_CONFIG_DIR / "portfolio.db"
+
+
+@dataclass
+class RuleThresholds:
+    cgt_window_days: int = 60
+    overweight_band: float = 0.02
+    concentration_limit: float = 0.25
+    drawdown_pct: float = 0.15
+    stale_note_days: int = 90
+
+
+@dataclass
+class Config:
+    base_currency: str = "AUD"
+    timezone: str = "Australia/Brisbane"
+    lot_matching: str = "FIFO"
+    brokerage_allocation: str = "BUY"
+    price_provider: str = "yfinance"
+    price_ttl_minutes: int = 15
+    offline_mode: bool = False
+    db_path: Path = DEFAULT_DB_PATH
+    target_weights: Dict[str, float] = field(default_factory=dict)
+    rule_thresholds: RuleThresholds = field(default_factory=RuleThresholds)
+
+    @property
+    def config_dir(self) -> Path:
+        return self.db_path.parent
+
+
+def _load_toml(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    with path.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def load_config(path: Optional[Path] = None) -> Config:
+    cfg_path = path or DEFAULT_CONFIG_PATH
+    data = _load_toml(cfg_path)
+
+    cfg = Config()
+
+    for key in ("base_currency", "timezone", "lot_matching", "brokerage_allocation", "price_provider"):
+        if key in data:
+            setattr(cfg, key, data[key])
+
+    if "price_ttl_minutes" in data:
+        cfg.price_ttl_minutes = int(data["price_ttl_minutes"])
+    if "offline_mode" in data:
+        cfg.offline_mode = bool(data["offline_mode"])
+
+    if "db_path" in data:
+        cfg.db_path = Path(data["db_path"]).expanduser()
+    else:
+        cfg.db_path = DEFAULT_DB_PATH
+
+    target_weights = data.get("target_weights", {})
+    cfg.target_weights = {k.upper(): float(v) for k, v in target_weights.items()}
+
+    rt = data.get("rule_thresholds", {})
+    cfg.rule_thresholds = RuleThresholds(
+        cgt_window_days=int(rt.get("cgt_window_days", cfg.rule_thresholds.cgt_window_days)),
+        overweight_band=float(rt.get("overweight_band", cfg.rule_thresholds.overweight_band)),
+        concentration_limit=float(rt.get("concentration_limit", cfg.rule_thresholds.concentration_limit)),
+        drawdown_pct=float(rt.get("drawdown_pct", cfg.rule_thresholds.drawdown_pct)),
+        stale_note_days=int(rt.get("stale_note_days", cfg.rule_thresholds.stale_note_days)),
+    )
+
+    return cfg
+
+
+def ensure_app_dirs(cfg: Config) -> None:
+    cfg.db_path.parent.mkdir(parents=True, exist_ok=True)
+
+
+__all__ = ["Config", "RuleThresholds", "load_config", "ensure_app_dirs", "DEFAULT_DB_PATH", "DEFAULT_CONFIG_PATH"]

--- a/portfolio_tool/core/cgt.py
+++ b/portfolio_tool/core/cgt.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from decimal import Decimal
+from zoneinfo import ZoneInfo
+
+
+@dataclass
+class DisposalBreakdown:
+    lot_id: int
+    qty: Decimal
+    proceeds: Decimal
+    cost_base: Decimal
+    gain_loss: Decimal
+    eligible_discount: bool
+    threshold_date: dt.date
+
+
+def cgt_threshold(acquired_at: dt.datetime, tz: str) -> dt.date:
+    tzinfo = ZoneInfo(tz)
+    local_date = acquired_at.astimezone(tzinfo).date()
+    return local_date + dt.timedelta(days=365)
+
+
+def compute_disposal(
+    lot_id: int,
+    qty: Decimal,
+    sell_price: Decimal,
+    sell_fees_alloc: Decimal,
+    lot_cost_base: Decimal,
+    lot_qty: Decimal,
+    acquired_at: dt.datetime,
+    disposal_dt: dt.datetime,
+    tz: str,
+) -> DisposalBreakdown:
+    proceeds = qty * sell_price - sell_fees_alloc
+    cost_ratio = qty / lot_qty
+    cost_base = lot_cost_base * cost_ratio
+    gain_loss = proceeds - cost_base
+    threshold_date = cgt_threshold(acquired_at, tz)
+    eligible_discount = disposal_dt.astimezone(ZoneInfo(tz)).date() > threshold_date
+    return DisposalBreakdown(
+        lot_id=lot_id,
+        qty=qty,
+        proceeds=proceeds,
+        cost_base=cost_base,
+        gain_loss=gain_loss,
+        eligible_discount=eligible_discount,
+        threshold_date=threshold_date,
+    )
+
+
+__all__ = ["DisposalBreakdown", "cgt_threshold", "compute_disposal"]

--- a/portfolio_tool/core/lots.py
+++ b/portfolio_tool/core/lots.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Iterable, List, Sequence
+
+from sqlalchemy.orm import Session
+
+from .cgt import compute_disposal
+
+
+@dataclass
+class LotSlice:
+    lot: any
+    qty: Decimal
+
+
+@dataclass
+class MatchedPiece:
+    lot_id: int
+    qty: Decimal
+
+
+def _sort_lots(lots: Sequence, method: str, specific_ids: Sequence[int] | None = None) -> List:
+    method = method.upper()
+    if method == "FIFO":
+        return sorted(lots, key=lambda l: (l.acquired_at, l.id))
+    if method == "HIFO":
+        return sorted(
+            lots,
+            key=lambda l: (Decimal(l.cost_base_total) / Decimal(l.qty_remaining), l.acquired_at),
+            reverse=True,
+        )
+    if method == "SPECIFIC_ID":
+        if not specific_ids:
+            raise ValueError("specific_ids required for SPECIFIC_ID matching")
+        id_order = {lot_id: idx for idx, lot_id in enumerate(specific_ids)}
+        return sorted(lots, key=lambda l: id_order.get(l.id, len(id_order)))
+    raise ValueError(f"Unknown lot matching method {method}")
+
+
+def match_disposal(
+    lots: Sequence,
+    sell_qty: Decimal,
+    method: str,
+    specific_ids: Sequence[int] | None = None,
+) -> list[LotSlice]:
+    remaining = sell_qty
+    ordered = _sort_lots(lots, method, specific_ids)
+    slices: list[LotSlice] = []
+    for lot in ordered:
+        if remaining <= Decimal("0"):
+            break
+        take = min(remaining, Decimal(lot.qty_remaining))
+        if take <= Decimal("0"):
+            continue
+        slices.append(LotSlice(lot=lot, qty=take))
+        remaining -= take
+    if remaining > Decimal("0"):
+        raise ValueError("Not enough quantity to match disposal")
+    return slices
+
+
+def apply_disposal(
+    session: Session,
+    lot_slices: Sequence[LotSlice],
+    sell_trade,
+    sell_qty: Decimal,
+    sell_price: Decimal,
+    fees_alloc: Decimal,
+    tz: str,
+):
+    for lot_slice in lot_slices:
+        lot = lot_slice.lot
+        breakdown = compute_disposal(
+            lot_id=lot.id,
+            qty=lot_slice.qty,
+            sell_price=sell_price,
+            sell_fees_alloc=fees_alloc * (lot_slice.qty / sell_qty) if sell_qty else Decimal("0"),
+            lot_cost_base=Decimal(lot.cost_base_total),
+            lot_qty=Decimal(lot.qty_remaining),
+            acquired_at=lot.acquired_at,
+            disposal_dt=sell_trade.dt,
+            tz=tz,
+        )
+        lot.qty_remaining = Decimal(lot.qty_remaining) - lot_slice.qty
+        lot.cost_base_total = Decimal(lot.cost_base_total) - breakdown.cost_base
+        session.add(breakdown_to_model(breakdown, sell_trade.id))
+        session.flush()
+        session.refresh(lot)
+
+
+def breakdown_to_model(breakdown, sell_trade_id: int):
+    from portfolio_tool.data import models
+
+    return models.Disposal(
+        sell_trade_id=sell_trade_id,
+        lot_id=breakdown.lot_id,
+        qty=breakdown.qty,
+        proceeds=breakdown.proceeds,
+        cost_base_alloc=breakdown.cost_base,
+        gain_loss=breakdown.gain_loss,
+        eligible_discount=breakdown.eligible_discount,
+    )
+
+
+__all__ = ["match_disposal", "LotSlice", "apply_disposal", "MatchedPiece"]

--- a/portfolio_tool/core/pricing.py
+++ b/portfolio_tool/core/pricing.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Dict, Iterable, Protocol
+
+from sqlalchemy.orm import Session
+
+from portfolio_tool.config import Config
+from portfolio_tool.data import repo
+
+
+@dataclass
+class PriceQuote:
+    symbol: str
+    price: Decimal
+    currency: str
+    asof: dt.datetime
+    provider: str
+
+
+class PriceProvider(Protocol):
+    def get_last(self, symbols: list[str]) -> dict[str, PriceQuote]:
+        ...
+
+
+class PriceService:
+    def __init__(self, cfg: Config, provider: PriceProvider):
+        self.cfg = cfg
+        self.provider = provider
+
+    @staticmethod
+    def _ensure_aware(value: dt.datetime | None) -> dt.datetime | None:
+        if value is None:
+            return None
+        if value.tzinfo is None:
+            return value.replace(tzinfo=dt.timezone.utc)
+        return value
+
+    def get_quotes(self, session: Session, symbols: Iterable[str]) -> dict[str, PriceQuote]:
+        symbols = [s.upper() for s in symbols]
+        results: dict[str, PriceQuote] = {}
+        to_fetch: list[str] = []
+        now = dt.datetime.now(dt.timezone.utc)
+        ttl = dt.timedelta(minutes=self.cfg.price_ttl_minutes)
+        for symbol in symbols:
+            cached = repo.get_price(session, symbol)
+            if cached:
+                cached.ttl_expires_at = self._ensure_aware(cached.ttl_expires_at)
+                cached.asof = self._ensure_aware(cached.asof)
+            if cached and cached.ttl_expires_at and cached.ttl_expires_at > now:
+                results[symbol] = PriceQuote(
+                    symbol=cached.symbol,
+                    price=Decimal(cached.price),
+                    currency=cached.currency,
+                    asof=self._ensure_aware(cached.asof) or now,
+                    provider=cached.provider,
+                )
+            else:
+                if cached:
+                    results[symbol] = PriceQuote(
+                        symbol=cached.symbol,
+                        price=Decimal(cached.price),
+                        currency=cached.currency,
+                        asof=self._ensure_aware(cached.asof) or now,
+                        provider=cached.provider,
+                    )
+                if not self.cfg.offline_mode:
+                    to_fetch.append(symbol)
+        fetched: dict[str, PriceQuote] = {}
+        if to_fetch and not self.cfg.offline_mode:
+            try:
+                fetched = self.provider.get_last(to_fetch)
+            except Exception:
+                fetched = {}
+        for symbol in symbols:
+            if symbol in fetched:
+                quote = fetched[symbol]
+                repo.upsert_price(
+                    session,
+                    symbol=symbol,
+                    price=quote.price,
+                    currency=quote.currency,
+                    asof=quote.asof,
+                    provider=quote.provider,
+                    ttl_expires_at=quote.asof + ttl,
+                    is_stale=False,
+                )
+                results[symbol] = quote
+            else:
+                cached = repo.get_price(session, symbol)
+                if cached:
+                    cached.ttl_expires_at = self._ensure_aware(cached.ttl_expires_at)
+                    cached.asof = self._ensure_aware(cached.asof)
+                    cached.is_stale = True
+                    repo.upsert_price(
+                        session,
+                        symbol=cached.symbol,
+                        price=Decimal(cached.price),
+                        currency=cached.currency,
+                        asof=self._ensure_aware(cached.asof) or now,
+                        provider=cached.provider,
+                        ttl_expires_at=self._ensure_aware(cached.ttl_expires_at) or now,
+                        is_stale=True,
+                    )
+        session.flush()
+        return results
+
+
+__all__ = ["PriceQuote", "PriceProvider", "PriceService"]

--- a/portfolio_tool/core/reports.py
+++ b/portfolio_tool/core/reports.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Iterable
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from portfolio_tool.config import Config
+from portfolio_tool.core.pricing import PriceQuote, PriceService
+from portfolio_tool.data import models
+
+
+@dataclass
+class PositionRow:
+    symbol: str
+    quantity: Decimal
+    cost_base: Decimal
+    avg_cost: Decimal
+    price: Decimal | None
+    currency: str | None
+    market_value: Decimal | None
+    unrealised_pl: Decimal | None
+    unrealised_pct: Decimal | None
+    weight: Decimal | None
+
+
+@dataclass
+class LotRow:
+    lot_id: int
+    symbol: str
+    acquired_at: dt.datetime
+    qty_remaining: Decimal
+    cost_base: Decimal
+    threshold_date: dt.date
+
+
+def _quantize(value: Decimal | None) -> Decimal | None:
+    if value is None:
+        return None
+    return value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def build_positions(session: Session, cfg: Config, pricing: PriceService) -> list[PositionRow]:
+    stmt = select(models.Lot).where(models.Lot.qty_remaining > 0)
+    lots = list(session.scalars(stmt))
+    aggregated: dict[str, dict[str, Decimal]] = {}
+    for lot in lots:
+        symbol = lot.symbol.upper()
+        data = aggregated.setdefault(
+            symbol,
+            {
+                "qty": Decimal("0"),
+                "cost": Decimal("0"),
+            },
+        )
+        data["qty"] += Decimal(lot.qty_remaining)
+        data["cost"] += Decimal(lot.cost_base_total)
+    quotes: dict[str, PriceQuote] = pricing.get_quotes(session, list(aggregated.keys())) if aggregated else {}
+    total_value = Decimal("0")
+    for symbol, data in aggregated.items():
+        quote = quotes.get(symbol)
+        if quote:
+            total_value += Decimal(data["qty"]) * Decimal(quote.price)
+    rows: list[PositionRow] = []
+    for symbol, data in sorted(aggregated.items()):
+        qty = data["qty"]
+        cost = data["cost"]
+        avg_cost = (cost / qty) if qty else Decimal("0")
+        quote = quotes.get(symbol)
+        if quote:
+            price = quote.price
+            currency = quote.currency
+            market_value = qty * price
+            unrealised_pl = market_value - cost
+            unrealised_pct = (unrealised_pl / cost) if cost else None
+            weight = (market_value / total_value) if total_value else None
+        else:
+            price = None
+            currency = None
+            market_value = None
+            unrealised_pl = None
+            unrealised_pct = None
+            weight = None
+        rows.append(
+            PositionRow(
+                symbol=symbol,
+                quantity=qty,
+                cost_base=cost,
+                avg_cost=avg_cost,
+                price=price,
+                currency=currency,
+                market_value=market_value,
+                unrealised_pl=unrealised_pl,
+                unrealised_pct=unrealised_pct,
+                weight=weight,
+            )
+        )
+    return rows
+
+
+def build_lots(session: Session, symbol: str) -> list[LotRow]:
+    stmt = select(models.Lot).where(models.Lot.symbol == symbol.upper()).order_by(models.Lot.acquired_at)
+    rows: list[LotRow] = []
+    for lot in session.scalars(stmt):
+        rows.append(
+            LotRow(
+                lot_id=lot.id,
+                symbol=lot.symbol,
+                acquired_at=lot.acquired_at,
+                qty_remaining=Decimal(lot.qty_remaining),
+                cost_base=Decimal(lot.cost_base_total),
+                threshold_date=lot.threshold_date,
+            )
+        )
+    return rows
+
+
+def build_cgt_calendar(session: Session, cfg: Config, window_days: int) -> list[LotRow]:
+    horizon = dt.date.today() + dt.timedelta(days=window_days)
+    stmt = select(models.Lot).where(
+        models.Lot.qty_remaining > 0,
+        models.Lot.threshold_date <= horizon,
+    )
+    lots = [
+        LotRow(
+            lot_id=lot.id,
+            symbol=lot.symbol,
+            acquired_at=lot.acquired_at,
+            qty_remaining=Decimal(lot.qty_remaining),
+            cost_base=Decimal(lot.cost_base_total),
+            threshold_date=lot.threshold_date,
+        )
+        for lot in session.scalars(stmt)
+    ]
+    lots.sort(key=lambda r: r.threshold_date)
+    return lots
+
+
+def build_pnl(session: Session, realised: bool = True) -> list[dict]:
+    if realised:
+        stmt = select(models.Disposal)
+        rows = []
+        for disposal in session.scalars(stmt):
+            rows.append(
+                {
+                    "symbol": disposal.lot.symbol,
+                    "lot_id": disposal.lot_id,
+                    "qty": Decimal(disposal.qty),
+                    "gain_loss": Decimal(disposal.gain_loss),
+                    "eligible_discount": disposal.eligible_discount,
+                }
+            )
+        return rows
+    else:
+        stmt = select(models.Lot).where(models.Lot.qty_remaining > 0)
+        rows = []
+        for lot in session.scalars(stmt):
+            rows.append(
+                {
+                    "symbol": lot.symbol,
+                    "lot_id": lot.id,
+                    "qty": Decimal(lot.qty_remaining),
+                    "cost_base": Decimal(lot.cost_base_total),
+                    "threshold_date": lot.threshold_date,
+                }
+            )
+        return rows
+
+
+def build_audit_log(session: Session) -> list[dict]:
+    stmt = select(models.AuditLog).order_by(models.AuditLog.created_at)
+    logs: list[dict] = []
+    for entry in session.scalars(stmt):
+        logs.append(
+            {
+                "id": entry.id,
+                "action": entry.action,
+                "entity": entry.entity,
+                "entity_id": entry.entity_id,
+                "created_at": entry.created_at,
+                "payload": entry.payload,
+            }
+        )
+    return logs
+
+
+__all__ = [
+    "build_positions",
+    "build_lots",
+    "build_cgt_calendar",
+    "build_pnl",
+    "build_audit_log",
+    "PositionRow",
+    "LotRow",
+]

--- a/portfolio_tool/core/rules.py
+++ b/portfolio_tool/core/rules.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Iterable, List
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from portfolio_tool.config import Config
+from portfolio_tool.data import models
+
+
+@dataclass
+class ActionableData:
+    type: str
+    symbol: str | None
+    message: str
+    due_at: dt.datetime | None = None
+
+
+def _now() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def generate_cgt_actionables(
+    session: Session, cfg: Config, lots: Iterable[models.Lot]
+) -> List[ActionableData]:
+    window = dt.timedelta(days=cfg.rule_thresholds.cgt_window_days)
+    today = _now().date()
+    actionables: list[ActionableData] = []
+    for lot in lots:
+        if lot.qty_remaining <= 0:
+            continue
+        threshold = lot.threshold_date
+        if threshold >= today and (threshold - today) <= window:
+            message = f"Lot {lot.id} in {lot.symbol} eligible for CGT discount on {threshold.isoformat()}"
+            due_at = dt.datetime.combine(threshold, dt.time.min, tzinfo=dt.timezone.utc)
+            actionables.append(
+                ActionableData(
+                    type="cgt_window",
+                    symbol=lot.symbol,
+                    message=message,
+                    due_at=due_at,
+                )
+            )
+    return actionables
+
+
+def generate_overweight_actionables(positions: list[dict], cfg: Config) -> List[ActionableData]:
+    actionables: list[ActionableData] = []
+    for pos in positions:
+        symbol = pos["symbol"] if isinstance(pos, dict) else pos.symbol
+        weight = (pos.get("weight") if isinstance(pos, dict) else getattr(pos, "weight", None)) or Decimal("0")
+        target = Decimal(str(cfg.target_weights.get(symbol, 0)))
+        if target and weight > target + Decimal(str(cfg.rule_thresholds.overweight_band)):
+            message = f"{symbol} weight {weight:.2%} exceeds target {target:.2%}"
+            actionables.append(ActionableData(type="overweight", symbol=symbol, message=message))
+    return actionables
+
+
+def generate_concentration_actionables(positions: list[dict], cfg: Config) -> List[ActionableData]:
+    if not positions:
+        return []
+    def _weight(p):
+        if isinstance(p, dict):
+            return p.get("weight", Decimal("0"))
+        return getattr(p, "weight", Decimal("0")) or Decimal("0")
+
+    top = max(positions, key=_weight)
+    limit = Decimal(str(cfg.rule_thresholds.concentration_limit))
+    weight = _weight(top)
+    symbol = top["symbol"] if isinstance(top, dict) else top.symbol
+    if weight > limit:
+        message = f"{symbol} concentration {weight:.2%} exceeds limit {limit:.2%}"
+        return [ActionableData(type="concentration", symbol=symbol, message=message)]
+    return []
+
+
+def generate_drawdown_actionables(positions: list[dict], cfg: Config) -> List[ActionableData]:
+    threshold = Decimal(str(cfg.rule_thresholds.drawdown_pct))
+    actionables: list[ActionableData] = []
+    for pos in positions:
+        unrealised_pct = pos.get("unrealised_pct") if isinstance(pos, dict) else getattr(pos, "unrealised_pct", None)
+        if unrealised_pct is None:
+            continue
+        if unrealised_pct < Decimal("0") and abs(unrealised_pct) > threshold:
+            symbol = pos["symbol"] if isinstance(pos, dict) else pos.symbol
+            message = f"{symbol} drawdown {unrealised_pct:.2%} exceeds {threshold:.2%}"
+            actionables.append(ActionableData(type="drawdown", symbol=symbol, message=message))
+    return actionables
+
+
+def generate_stale_note_actionables(session: Session, cfg: Config) -> List[ActionableData]:
+    cutoff = _now() - dt.timedelta(days=cfg.rule_thresholds.stale_note_days)
+    stmt = select(models.Trade).where(
+        models.Trade.note.is_not(None),
+        models.Trade.note != "",
+        models.Trade.updated_at < cutoff,
+    )
+    actionables: list[ActionableData] = []
+    for trade in session.scalars(stmt):
+        message = f"Trade {trade.id} note stale since {trade.updated_at.date().isoformat()}"
+        actionables.append(ActionableData(type="stale_note", symbol=trade.symbol, message=message))
+    return actionables
+
+
+def generate_all_actionables(
+    session: Session, cfg: Config, positions: list[dict], lots: Iterable[models.Lot]
+) -> List[ActionableData]:
+    actionables: list[ActionableData] = []
+    actionables.extend(generate_cgt_actionables(session, cfg, lots))
+    actionables.extend(generate_overweight_actionables(positions, cfg))
+    actionables.extend(generate_concentration_actionables(positions, cfg))
+    actionables.extend(generate_drawdown_actionables(positions, cfg))
+    actionables.extend(generate_stale_note_actionables(session, cfg))
+    return actionables
+
+
+__all__ = [
+    "ActionableData",
+    "generate_all_actionables",
+    "generate_cgt_actionables",
+    "generate_overweight_actionables",
+    "generate_concentration_actionables",
+    "generate_drawdown_actionables",
+    "generate_stale_note_actionables",
+]

--- a/portfolio_tool/core/trades.py
+++ b/portfolio_tool/core/trades.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Sequence
+
+from sqlalchemy.orm import Session
+
+from portfolio_tool.config import Config
+from portfolio_tool.core.cgt import cgt_threshold
+from portfolio_tool.core.lots import apply_disposal, match_disposal
+from portfolio_tool.data import repo
+
+
+@dataclass
+class TradeInput:
+    side: str
+    symbol: str
+    dt: dt.datetime
+    qty: Decimal
+    price: Decimal
+    fees: Decimal
+    exchange: str | None = None
+    note: str | None = None
+
+
+def record_trade(
+    session: Session,
+    cfg: Config,
+    trade_input: TradeInput,
+    match_method: str | None = None,
+    specific_ids: Sequence[int] | None = None,
+):
+    side = trade_input.side.upper()
+    symbol = trade_input.symbol.upper()
+    trade = repo.create_trade(
+        session,
+        {
+            "side": side,
+            "symbol": symbol,
+            "dt": trade_input.dt,
+            "qty": trade_input.qty,
+            "price": trade_input.price,
+            "fees": trade_input.fees,
+            "exchange": trade_input.exchange,
+            "note": trade_input.note,
+        },
+    )
+    if side == "BUY":
+        fee_allocation = Decimal("0")
+        if cfg.brokerage_allocation == "BUY":
+            fee_allocation = trade_input.fees
+        elif cfg.brokerage_allocation == "SPLIT":
+            fee_allocation = trade_input.fees / 2
+        cost_base = trade_input.qty * trade_input.price + fee_allocation
+        threshold = cgt_threshold(trade_input.dt, cfg.timezone)
+        repo.create_lot(
+            session,
+            symbol=symbol,
+            acquired_at=trade_input.dt,
+            qty=trade_input.qty,
+            cost_base=cost_base,
+            threshold_date=threshold,
+            trade_id=trade.id,
+        )
+    else:
+        fee_allocation = Decimal("0")
+        if cfg.brokerage_allocation == "SELL":
+            fee_allocation = trade_input.fees
+        elif cfg.brokerage_allocation == "SPLIT":
+            fee_allocation = trade_input.fees / 2
+        lots = repo.list_open_lots(session, symbol)
+        if not lots:
+            raise ValueError("No lots available to match SELL")
+        method = (match_method or cfg.lot_matching).upper()
+        lot_slices = match_disposal(lots, trade_input.qty, method, specific_ids)
+        apply_disposal(
+            session,
+            lot_slices,
+            sell_trade=trade,
+            sell_qty=trade_input.qty,
+            sell_price=trade_input.price,
+            fees_alloc=fee_allocation,
+            tz=cfg.timezone,
+        )
+    return trade
+
+
+__all__ = ["TradeInput", "record_trade"]

--- a/portfolio_tool/data/migrations/env.py
+++ b/portfolio_tool/data/migrations/env.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from portfolio_tool.data import models
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = models.Base.metadata
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/portfolio_tool/data/migrations/script.py.mako
+++ b/portfolio_tool/data/migrations/script.py.mako
@@ -1,0 +1,13 @@
+"""Alembic migration script."""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/portfolio_tool/data/migrations/versions/0001_initial.py
+++ b/portfolio_tool/data/migrations/versions/0001_initial.py
@@ -1,0 +1,111 @@
+"""Initial schema
+
+Revision ID: 0001
+Revises: 
+Create Date: 2024-01-01
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "trades",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("side", sa.String(length=4), nullable=False),
+        sa.Column("symbol", sa.String(length=16), nullable=False),
+        sa.Column("dt", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("qty", sa.Numeric(24, 8), nullable=False),
+        sa.Column("price", sa.Numeric(24, 8), nullable=False),
+        sa.Column("fees", sa.Numeric(24, 8), nullable=False, server_default="0"),
+        sa.Column("exchange", sa.String(length=16)),
+        sa.Column("note", sa.Text()),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True)),
+    )
+    op.create_index("ix_trades_symbol", "trades", ["symbol"])
+    op.create_index("ix_trades_dt", "trades", ["dt"])
+
+    op.create_table(
+        "lots",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("symbol", sa.String(length=16), nullable=False),
+        sa.Column("acquired_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("qty_remaining", sa.Numeric(24, 8), nullable=False),
+        sa.Column("cost_base_total", sa.Numeric(24, 8), nullable=False),
+        sa.Column("threshold_date", sa.Date(), nullable=False),
+        sa.Column("trade_id", sa.Integer(), sa.ForeignKey("trades.id"), nullable=False),
+    )
+    op.create_index("ix_lots_symbol", "lots", ["symbol"])
+
+    op.create_table(
+        "price_cache",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("symbol", sa.String(length=16), nullable=False),
+        sa.Column("price", sa.Numeric(24, 8), nullable=False),
+        sa.Column("currency", sa.String(length=3), nullable=False),
+        sa.Column("asof", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("provider", sa.String(length=32), nullable=False),
+        sa.Column("ttl_expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("is_stale", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+    )
+    op.create_index("ix_price_cache_symbol", "price_cache", ["symbol"])
+    op.create_index("ix_price_cache_asof", "price_cache", ["asof"])
+
+    op.create_table(
+        "actionables",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("type", sa.String(length=32), nullable=False),
+        sa.Column("symbol", sa.String(length=16)),
+        sa.Column("message", sa.Text(), nullable=False),
+        sa.Column("status", sa.String(length=16), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("due_at", sa.DateTime(timezone=True)),
+        sa.Column("context", sa.Text()),
+    )
+    op.create_index("ix_actionables_status", "actionables", ["status"])
+
+    op.create_table(
+        "disposals",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("sell_trade_id", sa.Integer(), sa.ForeignKey("trades.id"), nullable=False),
+        sa.Column("lot_id", sa.Integer(), sa.ForeignKey("lots.id"), nullable=False),
+        sa.Column("qty", sa.Numeric(24, 8), nullable=False),
+        sa.Column("proceeds", sa.Numeric(24, 8), nullable=False),
+        sa.Column("cost_base_alloc", sa.Numeric(24, 8), nullable=False),
+        sa.Column("gain_loss", sa.Numeric(24, 8), nullable=False),
+        sa.Column("eligible_discount", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+    )
+
+    op.create_table(
+        "audit_log",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("action", sa.String(length=16), nullable=False),
+        sa.Column("entity", sa.String(length=32), nullable=False),
+        sa.Column("entity_id", sa.Integer(), nullable=False),
+        sa.Column("payload", sa.Text()),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("audit_log")
+    op.drop_table("disposals")
+    op.drop_index("ix_actionables_status", table_name="actionables")
+    op.drop_table("actionables")
+    op.drop_index("ix_price_cache_asof", table_name="price_cache")
+    op.drop_index("ix_price_cache_symbol", table_name="price_cache")
+    op.drop_table("price_cache")
+    op.drop_index("ix_lots_symbol", table_name="lots")
+    op.drop_table("lots")
+    op.drop_index("ix_trades_dt", table_name="trades")
+    op.drop_index("ix_trades_symbol", table_name="trades")
+    op.drop_table("trades")

--- a/portfolio_tool/data/models.py
+++ b/portfolio_tool/data/models.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+from sqlalchemy import Boolean, Date, DateTime, ForeignKey, Integer, Numeric, String, Text
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class Trade(Base):
+    __tablename__ = "trades"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    side: Mapped[str] = mapped_column(String(4), nullable=False)
+    symbol: Mapped[str] = mapped_column(String(16), nullable=False, index=True)
+    dt: Mapped[dt.datetime] = mapped_column(DateTime(timezone=True), nullable=False, index=True)
+    qty: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
+    price: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
+    fees: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False, default=Decimal("0"))
+    exchange: Mapped[str | None] = mapped_column(String(16))
+    note: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[dt.datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: dt.datetime.now(dt.timezone.utc), nullable=False
+    )
+    updated_at: Mapped[dt.datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: dt.datetime.now(dt.timezone.utc),
+        onupdate=lambda: dt.datetime.now(dt.timezone.utc),
+    )
+
+    disposals: Mapped[list["Disposal"]] = relationship(
+        "Disposal", back_populates="sell_trade", cascade="all, delete-orphan"
+    )
+    lots: Mapped[list["Lot"]] = relationship(
+        "Lot", back_populates="trade", cascade="all, delete-orphan"
+    )
+
+
+class Lot(Base):
+    __tablename__ = "lots"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    symbol: Mapped[str] = mapped_column(String(16), index=True, nullable=False)
+    acquired_at: Mapped[dt.datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    qty_remaining: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
+    cost_base_total: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
+    threshold_date: Mapped[dt.date] = mapped_column(Date, nullable=False)
+    trade_id: Mapped[int] = mapped_column(ForeignKey("trades.id"), nullable=False)
+
+    trade: Mapped[Trade] = relationship("Trade", back_populates="lots")
+    disposals: Mapped[list["Disposal"]] = relationship(
+        "Disposal", back_populates="lot", cascade="all, delete-orphan"
+    )
+
+
+class Disposal(Base):
+    __tablename__ = "disposals"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    sell_trade_id: Mapped[int] = mapped_column(ForeignKey("trades.id"), nullable=False)
+    lot_id: Mapped[int] = mapped_column(ForeignKey("lots.id"), nullable=False)
+    qty: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
+    proceeds: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
+    cost_base_alloc: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
+    gain_loss: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
+    eligible_discount: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    sell_trade: Mapped[Trade] = relationship("Trade", back_populates="disposals")
+    lot: Mapped[Lot] = relationship("Lot", back_populates="disposals")
+
+
+class PriceCache(Base):
+    __tablename__ = "price_cache"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    symbol: Mapped[str] = mapped_column(String(16), index=True, nullable=False)
+    price: Mapped[Decimal] = mapped_column(Numeric(24, 8), nullable=False)
+    currency: Mapped[str] = mapped_column(String(3), nullable=False)
+    asof: Mapped[dt.datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    provider: Mapped[str] = mapped_column(String(32), nullable=False)
+    ttl_expires_at: Mapped[dt.datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    is_stale: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+
+
+class Actionable(Base):
+    __tablename__ = "actionables"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    type: Mapped[str] = mapped_column(String(32), nullable=False)
+    symbol: Mapped[str | None] = mapped_column(String(16))
+    message: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(String(16), nullable=False, index=True, default="open")
+    created_at: Mapped[dt.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=lambda: dt.datetime.now(dt.timezone.utc)
+    )
+    due_at: Mapped[dt.datetime | None] = mapped_column(DateTime(timezone=True))
+    context: Mapped[str | None] = mapped_column(Text)
+
+
+class AuditLog(Base):
+    __tablename__ = "audit_log"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    action: Mapped[str] = mapped_column(String(16), nullable=False)
+    entity: Mapped[str] = mapped_column(String(32), nullable=False)
+    entity_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    payload: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[dt.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=lambda: dt.datetime.now(dt.timezone.utc)
+    )
+

--- a/portfolio_tool/data/repo.py
+++ b/portfolio_tool/data/repo.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from datetime import datetime
+from decimal import Decimal
+from typing import Optional
+
+from sqlalchemy import create_engine, func, select
+from sqlalchemy.orm import Session, sessionmaker
+
+from portfolio_tool.config import Config, ensure_app_dirs
+from . import models
+
+
+class Database:
+    def __init__(self, cfg: Config):
+        ensure_app_dirs(cfg)
+        self.engine = create_engine(
+            f"sqlite:///{cfg.db_path}", connect_args={"check_same_thread": False}
+        )
+        self.Session = sessionmaker(self.engine, expire_on_commit=False)
+
+    def create_all(self):
+        models.Base.metadata.create_all(self.engine)
+
+    @contextmanager
+    def session_scope(self):
+        session = self.Session()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+
+def log_action(session: Session, action: str, entity: str, entity_id: int, payload: Optional[dict] = None):
+    session.add(
+        models.AuditLog(
+            action=action,
+            entity=entity,
+            entity_id=entity_id,
+            payload=json.dumps(payload, default=str) if payload else None,
+        )
+    )
+
+
+def create_trade(session: Session, trade_data: dict, lots: list[dict] | None = None) -> models.Trade:
+    trade = models.Trade(**trade_data)
+    session.add(trade)
+    session.flush()
+    log_action(session, "create", "trade", trade.id, trade_data)
+    if lots:
+        for lot in lots:
+            session.add(models.Lot(**lot))
+    return trade
+
+
+def update_trade(session: Session, trade_id: int, updates: dict) -> models.Trade:
+    trade = session.get(models.Trade, trade_id)
+    if not trade:
+        raise ValueError("Trade not found")
+    for key, value in updates.items():
+        setattr(trade, key, value)
+    log_action(session, "update", "trade", trade.id, updates)
+    session.flush()
+    return trade
+
+
+def delete_trade(session: Session, trade_id: int) -> None:
+    trade = session.get(models.Trade, trade_id)
+    if not trade:
+        raise ValueError("Trade not found")
+    log_action(session, "delete", "trade", trade.id, {"side": trade.side, "symbol": trade.symbol})
+    session.delete(trade)
+
+
+def create_lot(
+    session: Session,
+    *,
+    symbol: str,
+    acquired_at: datetime,
+    qty: Decimal,
+    cost_base: Decimal,
+    threshold_date,
+    trade_id: int,
+) -> models.Lot:
+    lot = models.Lot(
+        symbol=symbol,
+        acquired_at=acquired_at,
+        qty_remaining=qty,
+        cost_base_total=cost_base,
+        threshold_date=threshold_date,
+        trade_id=trade_id,
+    )
+    session.add(lot)
+    session.flush()
+    return lot
+
+
+def list_open_lots(session: Session, symbol: str) -> list[models.Lot]:
+    stmt = select(models.Lot).where(models.Lot.symbol == symbol, models.Lot.qty_remaining > 0)
+    return list(session.scalars(stmt))
+
+
+def create_disposal(
+    session: Session,
+    *,
+    sell_trade_id: int,
+    lot_id: int,
+    qty: Decimal,
+    proceeds: Decimal,
+    cost_base_alloc: Decimal,
+    gain_loss: Decimal,
+    eligible_discount: bool,
+):
+    disposal = models.Disposal(
+        sell_trade_id=sell_trade_id,
+        lot_id=lot_id,
+        qty=qty,
+        proceeds=proceeds,
+        cost_base_alloc=cost_base_alloc,
+        gain_loss=gain_loss,
+        eligible_discount=eligible_discount,
+    )
+    session.add(disposal)
+    return disposal
+
+
+def upsert_price(
+    session: Session,
+    *,
+    symbol: str,
+    price: Decimal,
+    currency: str,
+    asof: datetime,
+    provider: str,
+    ttl_expires_at: datetime,
+    is_stale: bool,
+):
+    stmt = select(models.PriceCache).where(models.PriceCache.symbol == symbol)
+    existing = session.scalars(stmt).first()
+    if existing:
+        existing.price = price
+        existing.currency = currency
+        existing.asof = asof
+        existing.provider = provider
+        existing.ttl_expires_at = ttl_expires_at
+        existing.is_stale = is_stale
+        return existing
+    price_obj = models.PriceCache(
+        symbol=symbol,
+        price=price,
+        currency=currency,
+        asof=asof,
+        provider=provider,
+        ttl_expires_at=ttl_expires_at,
+        is_stale=is_stale,
+    )
+    session.add(price_obj)
+    return price_obj
+
+
+def get_price(session: Session, symbol: str) -> models.PriceCache | None:
+    stmt = select(models.PriceCache).where(models.PriceCache.symbol == symbol)
+    return session.scalars(stmt).first()
+
+
+def list_positions(session: Session):
+    stmt = select(models.Lot.symbol, func.sum(models.Lot.qty_remaining), func.sum(models.Lot.cost_base_total)).group_by(models.Lot.symbol)
+    return session.execute(stmt).all()
+
+
+def create_actionable(session: Session, **data):
+    actionable = models.Actionable(**data)
+    session.add(actionable)
+    return actionable
+
+
+def list_actionables(session: Session, status: str = "open") -> list[models.Actionable]:
+    stmt = select(models.Actionable).where(models.Actionable.status == status)
+    return list(session.scalars(stmt))
+
+
+__all__ = [
+    "Database",
+    "create_trade",
+    "update_trade",
+    "delete_trade",
+    "create_lot",
+    "list_open_lots",
+    "create_disposal",
+    "upsert_price",
+    "get_price",
+    "list_positions",
+    "create_actionable",
+    "list_actionables",
+    "log_action",
+]

--- a/portfolio_tool/providers/yahooquery_provider.py
+++ b/portfolio_tool/providers/yahooquery_provider.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+from yahooquery import Ticker
+
+from portfolio_tool.core.pricing import PriceQuote
+
+
+class YahooQueryProvider:
+    provider_name = "yahooquery"
+
+    def get_last(self, symbols: list[str]) -> dict[str, PriceQuote]:
+        results: dict[str, PriceQuote] = {}
+        if not symbols:
+            return results
+        tick = Ticker(symbols)
+        prices = tick.price
+        now = dt.datetime.now(dt.timezone.utc)
+        if isinstance(prices, dict):
+            for symbol in symbols:
+                info = prices.get(symbol)
+                if not info:
+                    continue
+                price = info.get("regularMarketPrice")
+                currency = info.get("currency", "USD")
+                if price is None:
+                    continue
+                results[symbol] = PriceQuote(
+                    symbol=symbol,
+                    price=Decimal(str(price)),
+                    currency=currency,
+                    asof=now,
+                    provider=self.provider_name,
+                )
+        return results
+
+
+__all__ = ["YahooQueryProvider"]

--- a/portfolio_tool/providers/yfinance_provider.py
+++ b/portfolio_tool/providers/yfinance_provider.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import yfinance as yf
+
+from portfolio_tool.core.pricing import PriceQuote
+
+
+class YFinanceProvider:
+    provider_name = "yfinance"
+
+    def get_last(self, symbols: list[str]) -> dict[str, PriceQuote]:
+        results: dict[str, PriceQuote] = {}
+        now = dt.datetime.now(dt.timezone.utc)
+        if not symbols:
+            return results
+        data = yf.download(symbols, period="1d", interval="1d", progress=False, auto_adjust=False)
+        if hasattr(data, "empty") and data.empty:
+            return results
+        if hasattr(data, "columns") and ("Close" in data.columns or isinstance(data.columns, tuple)):
+            close_data = data["Close"]
+            if getattr(close_data, "columns", None) is not None:
+                for symbol in symbols:
+                    if symbol in close_data.columns:
+                        price = Decimal(str(close_data[symbol].iloc[-1]))
+                        results[symbol] = PriceQuote(
+                            symbol=symbol,
+                            price=price,
+                            currency="USD",
+                            asof=now,
+                            provider=self.provider_name,
+                        )
+                return results
+            if not getattr(close_data, "empty", True):
+                price = Decimal(str(close_data.iloc[-1]))
+                results[symbols[0]] = PriceQuote(
+                    symbol=symbols[0],
+                    price=price,
+                    currency="USD",
+                    asof=now,
+                    provider=self.provider_name,
+                )
+                return results
+        # fallback per symbol
+        for symbol in symbols:
+            ticker = yf.Ticker(symbol)
+            hist = ticker.history(period="1d")
+            if hist.empty:
+                continue
+            price = Decimal(str(hist["Close"].iloc[-1]))
+            results[symbol] = PriceQuote(
+                symbol=symbol,
+                price=price,
+                currency="USD",
+                asof=now,
+                provider=self.provider_name,
+            )
+        return results
+
+
+__all__ = ["YFinanceProvider"]

--- a/portfolio_tool/reports/md_renderer.py
+++ b/portfolio_tool/reports/md_renderer.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from decimal import Decimal
+from typing import Iterable
+
+from portfolio_tool.core.reports import LotRow, PositionRow
+
+
+def _fmt(value: Decimal | None, fmt: str = "{:.2f}") -> str:
+    if value is None:
+        return "-"
+    return fmt.format(value)
+
+
+def positions_markdown(rows: Iterable[PositionRow]) -> str:
+    headers = [
+        "Symbol",
+        "Qty",
+        "Avg Cost",
+        "Last Price",
+        "Market Value",
+        "Unrealised $",
+        "Unrealised %",
+        "Weight",
+    ]
+    lines = ["| " + " | ".join(headers) + " |", "|" + " --- |" * len(headers)]
+    for row in rows:
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    row.symbol,
+                    _fmt(row.quantity, "{:.4f}"),
+                    _fmt(row.avg_cost),
+                    _fmt(row.price),
+                    _fmt(row.market_value),
+                    _fmt(row.unrealised_pl),
+                    _fmt(row.unrealised_pct, "{:.2%}"),
+                    _fmt(row.weight, "{:.2%}"),
+                ]
+            )
+            + " |"
+        )
+    return "\n".join(lines)
+
+
+def lots_markdown(rows: Iterable[LotRow]) -> str:
+    headers = ["Lot ID", "Symbol", "Acquired", "Qty", "Cost Base", "CGT Threshold"]
+    lines = ["| " + " | ".join(headers) + " |", "|" + " --- |" * len(headers)]
+    for row in rows:
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(row.lot_id),
+                    row.symbol,
+                    row.acquired_at.isoformat(),
+                    _fmt(row.qty_remaining, "{:.4f}"),
+                    _fmt(row.cost_base),
+                    row.threshold_date.isoformat(),
+                ]
+            )
+            + " |"
+        )
+    return "\n".join(lines)
+
+
+__all__ = ["positions_markdown", "lots_markdown"]

--- a/portfolio_tool/reports/tables.py
+++ b/portfolio_tool/reports/tables.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Iterable
+
+from rich.table import Table
+
+from portfolio_tool.core.reports import LotRow, PositionRow
+
+
+def _fmt_decimal(value: Decimal | None, fmt: str = "{:.2f}") -> str:
+    if value is None:
+        return "-"
+    return fmt.format(value)
+
+
+def positions_table(rows: Iterable[PositionRow]) -> Table:
+    table = Table(title="Positions")
+    table.add_column("Symbol")
+    table.add_column("Qty")
+    table.add_column("Avg Cost")
+    table.add_column("Last Price")
+    table.add_column("Market Value")
+    table.add_column("Unrealised $")
+    table.add_column("Unrealised %")
+    table.add_column("Weight")
+    for row in rows:
+        table.add_row(
+            row.symbol,
+            _fmt_decimal(row.quantity, "{:.4f}"),
+            _fmt_decimal(row.avg_cost),
+            _fmt_decimal(row.price),
+            _fmt_decimal(row.market_value),
+            _fmt_decimal(row.unrealised_pl),
+            _fmt_decimal(row.unrealised_pct, "{:.2%}"),
+            _fmt_decimal(row.weight, "{:.2%}"),
+        )
+    return table
+
+
+def lots_table(rows: Iterable[LotRow]) -> Table:
+    table = Table(title="Lots")
+    table.add_column("Lot ID")
+    table.add_column("Symbol")
+    table.add_column("Acquired")
+    table.add_column("Qty")
+    table.add_column("Cost Base")
+    table.add_column("CGT Threshold")
+    for row in rows:
+        table.add_row(
+            str(row.lot_id),
+            row.symbol,
+            row.acquired_at.isoformat(),
+            _fmt_decimal(row.qty_remaining, "{:.4f}"),
+            _fmt_decimal(row.cost_base),
+            row.threshold_date.isoformat(),
+        )
+    return table
+
+
+__all__ = ["positions_table", "lots_table"]

--- a/portfolio_tool/tests/conftest.py
+++ b/portfolio_tool/tests/conftest.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from portfolio_tool.config import Config
+from portfolio_tool.data.repo import Database
+
+
+@pytest.fixture
+def cfg(tmp_path: Path) -> Config:
+    config = Config()
+    config.db_path = tmp_path / "portfolio.db"
+    return config
+
+
+@pytest.fixture
+def db(cfg: Config) -> Database:
+    database = Database(cfg)
+    database.create_all()
+    return database
+
+
+@pytest.fixture
+def session(db: Database):
+    with db.session_scope() as session:
+        yield session

--- a/portfolio_tool/tests/golden/positions.md
+++ b/portfolio_tool/tests/golden/positions.md
@@ -1,0 +1,3 @@
+| Symbol | Qty | Avg Cost | Last Price | Market Value | Unrealised $ | Unrealised % | Weight |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| AAA | 10.0000 | 10.50 | 12.00 | 120.00 | 15.00 | 14.29% | 100.00% |

--- a/portfolio_tool/tests/test_brokerage.py
+++ b/portfolio_tool/tests/test_brokerage.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+from sqlalchemy import select
+
+from portfolio_tool.core.trades import TradeInput, record_trade
+from portfolio_tool.data import models
+
+
+def _buy_trade(dt_value: dt.datetime, fees: str, cfg, session):
+    record_trade(
+        session,
+        cfg,
+        TradeInput(
+            side="BUY",
+            symbol="XYZ",
+            dt=dt_value,
+            qty=Decimal("10"),
+            price=Decimal("10"),
+            fees=Decimal(fees),
+        ),
+    )
+
+
+def _sell_trade(dt_value: dt.datetime, fees: str, cfg, session):
+    record_trade(
+        session,
+        cfg,
+        TradeInput(
+            side="SELL",
+            symbol="XYZ",
+            dt=dt_value,
+            qty=Decimal("10"),
+            price=Decimal("12"),
+            fees=Decimal(fees),
+        ),
+    )
+
+
+def test_buy_allocation_increases_cost_base(cfg, db):
+    cfg.brokerage_allocation = "BUY"
+    base_dt = dt.datetime(2023, 1, 1, tzinfo=dt.timezone.utc)
+    with db.session_scope() as session:
+        _buy_trade(base_dt, "10", cfg, session)
+        lot = session.scalars(select(models.Lot)).one()
+        assert Decimal(lot.cost_base_total) == Decimal("110")
+
+
+def test_sell_allocation_reduces_proceeds(cfg, db):
+    cfg.brokerage_allocation = "SELL"
+    base_dt = dt.datetime(2023, 1, 1, tzinfo=dt.timezone.utc)
+    with db.session_scope() as session:
+        _buy_trade(base_dt, "0", cfg, session)
+        _sell_trade(base_dt + dt.timedelta(days=2), "10", cfg, session)
+        disposal = session.scalars(select(models.Disposal)).one()
+        assert Decimal(disposal.proceeds) == Decimal("110")
+
+
+def test_split_allocation_shares_fees(cfg, db):
+    cfg.brokerage_allocation = "SPLIT"
+    base_dt = dt.datetime(2023, 1, 1, tzinfo=dt.timezone.utc)
+    with db.session_scope() as session:
+        _buy_trade(base_dt, "10", cfg, session)
+        lot = session.scalars(select(models.Lot)).one()
+        assert Decimal(lot.cost_base_total) == Decimal("105")
+        _sell_trade(base_dt + dt.timedelta(days=2), "10", cfg, session)
+        disposal = session.scalars(select(models.Disposal)).one()
+        assert Decimal(disposal.proceeds) == Decimal("115")

--- a/portfolio_tool/tests/test_cgt.py
+++ b/portfolio_tool/tests/test_cgt.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+from portfolio_tool.core.cgt import compute_disposal, cgt_threshold
+
+
+def test_cgt_threshold_handles_leap_year():
+    acquired = dt.datetime(2023, 3, 1, 10, tzinfo=dt.timezone.utc)
+    threshold = cgt_threshold(acquired, "Australia/Brisbane")
+    assert threshold == dt.date(2024, 2, 29)
+
+
+def test_compute_disposal_discount_flag():
+    acquired = dt.datetime(2022, 1, 1, tzinfo=dt.timezone.utc)
+    disposal_dt = dt.datetime(2023, 1, 5, tzinfo=dt.timezone.utc)
+    breakdown = compute_disposal(
+        lot_id=1,
+        qty=Decimal("5"),
+        sell_price=Decimal("12"),
+        sell_fees_alloc=Decimal("1"),
+        lot_cost_base=Decimal("100"),
+        lot_qty=Decimal("10"),
+        acquired_at=acquired,
+        disposal_dt=disposal_dt,
+        tz="Australia/Brisbane",
+    )
+    assert breakdown.eligible_discount is True
+    assert breakdown.gain_loss == Decimal("9")

--- a/portfolio_tool/tests/test_lots.py
+++ b/portfolio_tool/tests/test_lots.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+from sqlalchemy import select
+
+from portfolio_tool.core.trades import TradeInput, record_trade
+from portfolio_tool.data import models
+
+
+def _trade(dt_value: dt.datetime, qty: str, price: str, side: str = "BUY") -> TradeInput:
+    return TradeInput(
+        side=side,
+        symbol="ABC",
+        dt=dt_value,
+        qty=Decimal(qty),
+        price=Decimal(price),
+        fees=Decimal("0"),
+    )
+
+
+def test_fifo_matching(cfg, db):
+    cfg.lot_matching = "FIFO"
+    base_dt = dt.datetime(2023, 1, 1, tzinfo=dt.timezone.utc)
+    with db.session_scope() as session:
+        record_trade(session, cfg, _trade(base_dt, "10", "10"))
+        record_trade(session, cfg, _trade(base_dt + dt.timedelta(days=1), "10", "12"))
+        lot_ids = [
+            lot.id
+            for lot in session.scalars(select(models.Lot).order_by(models.Lot.acquired_at))
+        ]
+        record_trade(
+            session,
+            cfg,
+            TradeInput(
+                side="SELL",
+                symbol="ABC",
+                dt=base_dt + dt.timedelta(days=2),
+                qty=Decimal("15"),
+                price=Decimal("20"),
+                fees=Decimal("0"),
+            ),
+            match_method="FIFO",
+        )
+        disposals = list(session.scalars(select(models.Disposal).order_by(models.Disposal.id)))
+        assert [d.lot_id for d in disposals] == lot_ids
+        assert [Decimal(d.qty) for d in disposals] == [Decimal("10"), Decimal("5")]
+
+
+def test_hifo_matching(cfg, db):
+    cfg.lot_matching = "HIFO"
+    base_dt = dt.datetime(2023, 1, 1, tzinfo=dt.timezone.utc)
+    with db.session_scope() as session:
+        record_trade(session, cfg, _trade(base_dt, "10", "10"))
+        record_trade(session, cfg, _trade(base_dt + dt.timedelta(days=1), "10", "12"))
+        lots = list(session.scalars(select(models.Lot).order_by(models.Lot.acquired_at)))
+        high_cost_lot = lots[1]
+        record_trade(
+            session,
+            cfg,
+            TradeInput(
+                side="SELL",
+                symbol="ABC",
+                dt=base_dt + dt.timedelta(days=2),
+                qty=Decimal("5"),
+                price=Decimal("20"),
+                fees=Decimal("0"),
+            ),
+            match_method="HIFO",
+        )
+        disposal = session.scalars(select(models.Disposal)).one()
+        assert disposal.lot_id == high_cost_lot.id
+
+
+def test_specific_id_matching(cfg, db):
+    cfg.lot_matching = "SPECIFIC_ID"
+    base_dt = dt.datetime(2023, 1, 1, tzinfo=dt.timezone.utc)
+    with db.session_scope() as session:
+        record_trade(session, cfg, _trade(base_dt, "10", "10"))
+        record_trade(session, cfg, _trade(base_dt + dt.timedelta(days=1), "10", "12"))
+        lots = list(session.scalars(select(models.Lot).order_by(models.Lot.acquired_at)))
+        target_lot = lots[0]
+        record_trade(
+            session,
+            cfg,
+            TradeInput(
+                side="SELL",
+                symbol="ABC",
+                dt=base_dt + dt.timedelta(days=2),
+                qty=Decimal("5"),
+                price=Decimal("20"),
+                fees=Decimal("0"),
+            ),
+            match_method="SPECIFIC_ID",
+            specific_ids=[target_lot.id],
+        )
+        disposal = session.scalars(select(models.Disposal)).one()
+        assert disposal.lot_id == target_lot.id

--- a/portfolio_tool/tests/test_markdown.py
+++ b/portfolio_tool/tests/test_markdown.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+from pathlib import Path
+
+from portfolio_tool.core.pricing import PriceQuote, PriceService
+from portfolio_tool.core.reports import build_positions
+from portfolio_tool.core.trades import TradeInput, record_trade
+from portfolio_tool.reports.md_renderer import positions_markdown
+
+
+class StaticProvider:
+    def get_last(self, symbols: list[str]):
+        now = dt.datetime.now(dt.timezone.utc)
+        return {
+            symbol: PriceQuote(
+                symbol=symbol,
+                price=Decimal("12"),
+                currency="AUD",
+                asof=now,
+                provider="static",
+            )
+            for symbol in symbols
+        }
+
+
+def test_positions_markdown_golden(cfg, db):
+    provider = StaticProvider()
+    service = PriceService(cfg, provider)
+    base_dt = dt.datetime(2023, 1, 1, tzinfo=dt.timezone.utc)
+    with db.session_scope() as session:
+        record_trade(
+            session,
+            cfg,
+            TradeInput(
+                side="BUY",
+                symbol="AAA",
+                dt=base_dt,
+                qty=Decimal("10"),
+                price=Decimal("10"),
+                fees=Decimal("5"),
+            ),
+        )
+        positions = build_positions(session, cfg, service)
+        md = positions_markdown(positions)
+    golden = Path(__file__).parent / "golden" / "positions.md"
+    assert md.strip() == golden.read_text(encoding="utf-8").strip()

--- a/portfolio_tool/tests/test_pricing.py
+++ b/portfolio_tool/tests/test_pricing.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+from portfolio_tool.core.pricing import PriceQuote, PriceService
+from portfolio_tool.data import repo
+
+
+class DummyProvider:
+    def __init__(self, price: str = "100") -> None:
+        self.price = Decimal(price)
+        self.call_count = 0
+        self.raise_error = False
+
+    def get_last(self, symbols: list[str]) -> dict[str, PriceQuote]:
+        self.call_count += 1
+        if self.raise_error:
+            raise RuntimeError("provider down")
+        now = dt.datetime.now(dt.timezone.utc)
+        return {
+            symbol: PriceQuote(
+                symbol=symbol,
+                price=self.price,
+                currency="USD",
+                asof=now,
+                provider="dummy",
+            )
+            for symbol in symbols
+        }
+
+
+def test_price_caching_respects_ttl(cfg, db):
+    provider = DummyProvider("123")
+    service = PriceService(cfg, provider)
+    with db.session_scope() as session:
+        quotes = service.get_quotes(session, ["AAA"])
+        assert provider.call_count == 1
+        quotes = service.get_quotes(session, ["AAA"])
+        assert provider.call_count == 1
+        assert quotes["AAA"].price == Decimal("123")
+
+
+def test_price_fallback_marks_stale(cfg, db):
+    provider = DummyProvider("50")
+    service = PriceService(cfg, provider)
+    with db.session_scope() as session:
+        service.get_quotes(session, ["BBB"])
+        cached = repo.get_price(session, "BBB")
+        cached.ttl_expires_at = dt.datetime.now(dt.timezone.utc) - dt.timedelta(minutes=1)
+        provider.raise_error = True
+        quotes = service.get_quotes(session, ["BBB"])
+        cached = repo.get_price(session, "BBB")
+        assert cached.is_stale is True
+        assert quotes["BBB"].price == Decimal("50")
+        assert provider.call_count == 2

--- a/portfolio_tool/tests/test_rules.py
+++ b/portfolio_tool/tests/test_rules.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+from sqlalchemy import select
+
+from portfolio_tool.core.pricing import PriceQuote, PriceService
+from portfolio_tool.core.reports import build_positions
+from portfolio_tool.core.rules import generate_all_actionables
+from portfolio_tool.core.trades import TradeInput, record_trade
+from portfolio_tool.data import models
+
+
+class MappingProvider:
+    def __init__(self, prices: dict[str, Decimal]):
+        self.prices = prices
+
+    def get_last(self, symbols: list[str]) -> dict[str, PriceQuote]:
+        now = dt.datetime.now(dt.timezone.utc)
+        return {
+            symbol: PriceQuote(
+                symbol=symbol,
+                price=self.prices[symbol],
+                currency="AUD",
+                asof=now,
+                provider="mapping",
+            )
+            for symbol in symbols
+        }
+
+
+def test_actionables_cover_rules(cfg, db):
+    cfg.target_weights = {"AAA": 0.2, "BBB": 0.1}
+    cfg.rule_thresholds.cgt_window_days = 120
+    cfg.rule_thresholds.overweight_band = 0.01
+    cfg.rule_thresholds.concentration_limit = 0.3
+    cfg.rule_thresholds.drawdown_pct = 0.1
+    cfg.rule_thresholds.stale_note_days = 30
+
+    provider = MappingProvider({"AAA": Decimal("20"), "BBB": Decimal("5")})
+    service = PriceService(cfg, provider)
+
+    with db.session_scope() as session:
+        old_dt = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=350)
+        recent_dt = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=10)
+        record_trade(
+            session,
+            cfg,
+            TradeInput(
+                side="BUY",
+                symbol="AAA",
+                dt=old_dt,
+                qty=Decimal("10"),
+                price=Decimal("10"),
+                fees=Decimal("0"),
+                note="Long term",
+            ),
+        )
+        record_trade(
+            session,
+            cfg,
+            TradeInput(
+                side="BUY",
+                symbol="BBB",
+                dt=recent_dt,
+                qty=Decimal("10"),
+                price=Decimal("10"),
+                fees=Decimal("0"),
+            ),
+        )
+        # Force note to appear stale
+        trade = session.scalars(select(models.Trade).where(models.Trade.symbol == "AAA")).first()
+        trade.updated_at = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=120)
+        positions = build_positions(session, cfg, service)
+        lots = list(session.scalars(select(models.Lot)))
+        actionables = generate_all_actionables(session, cfg, positions, lots)
+        types = {a.type for a in actionables}
+        assert {"cgt_window", "overweight", "concentration", "drawdown", "stale_note"} <= types

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,41 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "portfolio-tool"
+version = "0.1.0"
+description = "Command-line portfolio tracker for ASX/US equities"
+authors = [{name = "StockTrak", email = "dev@example.com"}]
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "typer[all]>=0.9",
+    "sqlalchemy>=2.0",
+    "alembic>=1.12",
+    "pydantic>=2.5",
+    "yfinance>=0.2",
+    "yahooquery>=2.3",
+    "rich>=13.7",
+    "pytz>=2023.3",
+]
+
+[project.optional-dependencies]
+dev = ["pytest", "pytest-cov", "freezegun", "python-dateutil"]
+
+[project.scripts]
+portfolio = "portfolio_tool.__main__:app"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+addopts = "-q"
+
+[tool.black]
+line-length = 88
+
+[tool.isort]
+profile = "black"
+
+[tool.ruff]
+line-length = 88
+


### PR DESCRIPTION
## Summary
- scaffold a Typer-based CLI with trade management, reporting, pricing refresh, actionables, and config subcommands
- implement core services for lot matching, CGT, pricing cache, reporting, and persistence with SQLAlchemy models and migrations
- document usage and pricing behaviour and add pytest coverage for matching, CGT, brokerage allocation, caching, rules, and markdown exports

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9d8e43b9483228fda0598511c5634