### PR TITLE
Add configurable pricing fallback chain with ASX normalization

### DIFF
--- a/PRICING.md
+++ b/PRICING.md
@@ -1,27 +1,46 @@
 # Pricing Providers & Cache
 
-The portfolio tool resolves last-traded prices through a provider abstraction defined in `portfolio_tool.core.pricing`. Two providers are bundled:
+The portfolio tool resolves last-traded prices through the `PriceProvider` protocol defined in `portfolio_tool.core.pricing`. A resilient fallback chain is bundled so a single outage will not block price refreshes.
 
-- **Yahoo Finance (yfinance)** – default provider using the community yfinance package.
-- **YahooQuery** – optional alternative using the yahooquery client.
+## Provider order & normalisation
 
-> ⚠️ Both integrations call unofficial Yahoo Finance endpoints which may change without notice. The application remains functional offline by falling back to cached values stored in SQLite.
+1. **Primary – yfinance** (default) fetches end-of-day closes from Yahoo Finance. Empty responses, HTTP failures and "decrypt" errors are logged and trigger the fallback chain.
+2. **Secondary – yahooquery** mirrors Yahoo Finance via the yahooquery client.
+3. **Optional – Market Index data API** requests read-only JSON endpoints at `https://data-api.marketindex.com.au/`. Enable explicitly and expect schema changes.
+4. **Tertiary – Alpha Vantage** uses the `TIME_SERIES_DAILY_ADJUSTED` endpoint when an API key is configured.
 
-## Cache Behaviour
+Symbols are normalised automatically for Australian users. When `pricing.normalize_asx_suffix = true` and your `timezone` starts with `Australia/`, an unsuffixed ticker such as `CSL` is transparently retried as `CSL.AX` before moving to the next provider. Quotes are always returned under the original symbol for cache/storage consistency.
 
-- Quotes are cached in the `price_cache` table with a configurable TTL (`price_ttl_minutes`, default 15 minutes).
+> ⚠️ All bundled integrations rely on unofficial/community data feeds. The official ASX market price feed requires licensed vendor access; use that for guaranteed low-latency data.
+
+## Cache behaviour
+
+- Quotes are cached in the `price_cache` table with a configurable TTL. Set `pricing.price_ttl_minutes` (default 15 minutes) to control refresh cadence.
 - When a request arrives:
-  - If a cached quote is fresh (`ttl_expires_at` in the future), it is returned without a network call.
-  - If the cache is stale and `offline_mode = false`, the provider is queried and the cache is refreshed.
-  - If the provider fails or `offline_mode = true`, the most recent cached quote is returned and marked `is_stale = true`.
+  - If a cached quote is fresh (`ttl_expires_at` in the future) it is returned without hitting the network.
+  - If the cache is stale and `offline_mode = false`, the provider chain is queried and the cache is refreshed.
+  - If every provider fails or `offline_mode = true`, the most recent cached quote is returned, marked `is_stale = true`, and a warning is logged.
 - The `price-refresh` CLI command forces a refresh for specific tickers.
 
-## Switching Providers
+## Configuration
 
-Update `~/.portfolio_tool/config.toml` (or use `portfolio config set`) to change provider:
+New pricing settings live under the `[pricing]` table in `~/.portfolio_tool/config.toml`:
 
 ```toml
-price_provider = "yahooquery"
+[pricing]
+provider_primary = "yfinance"
+fallbacks = ["yahooquery", "marketindex", "alphavantage"]
+price_ttl_minutes = 15
+normalize_asx_suffix = true
+include_marketindex = false  # opt-in; experimental
+
+[alpha_vantage]
+api_key = ""
 ```
 
-Any provider implementing the `PriceProvider` protocol can be registered in `portfolio_tool.__main__.py`.
+- Set `pricing.provider_primary` to change the first provider in the chain.
+- Reorder or trim `pricing.fallbacks` to suit your data sources.
+- Flip `pricing.include_marketindex` to `true` to opt-in to the Market Index experiment. The endpoint is undocumented, may change without notice, and should be used at your own risk.
+- Provide `alpha_vantage.api_key` to activate the Alpha Vantage fallback. Symbols targeting the ASX are automatically queried as `SYMBOL.AX`.
+
+Any other provider implementing the `PriceProvider` protocol can be registered in `portfolio_tool.providers.fallback_provider.FallbackPriceProvider`.

--- a/portfolio_tool/__main__.py
+++ b/portfolio_tool/__main__.py
@@ -26,8 +26,7 @@ from portfolio_tool.core.rules import generate_all_actionables
 from portfolio_tool.core.trades import TradeInput, record_trade
 from portfolio_tool.data import models, repo
 from portfolio_tool.data.repo import Database
-from portfolio_tool.providers.yfinance_provider import YFinanceProvider
-from portfolio_tool.providers.yahooquery_provider import YahooQueryProvider
+from portfolio_tool.providers.fallback_provider import FallbackPriceProvider
 from ui.textual_app import PortfolioApp, PortfolioServices, build_services
 from portfolio_tool.reports import md_renderer, tables
 from sqlalchemy import select
@@ -39,9 +38,7 @@ app.add_typer(config_app, name="config")
 
 
 def get_provider(cfg: Config):
-    if cfg.price_provider == "yahooquery":
-        return YahooQueryProvider()
-    return YFinanceProvider()
+    return FallbackPriceProvider(cfg)
 
 
 @app.callback()

--- a/portfolio_tool/providers/alphavantage_provider.py
+++ b/portfolio_tool/providers/alphavantage_provider.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+import logging
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Callable
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from portfolio_tool.core.pricing import PriceQuote
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _default_opener(request: Request):
+    return urlopen(request)  # noqa: S310 - simple GET
+
+
+@dataclass
+class AlphaVantageProvider:
+    provider_name: str = "alphavantage"
+    api_key: str = ""
+    base_url: str = "https://www.alphavantage.co/query"
+    currency: str = "USD"
+    _opener: Callable[[Request], Any] = _default_opener
+
+    def _build_url(self, symbol: str) -> str:
+        params = urlencode(
+            {
+                "function": "TIME_SERIES_DAILY_ADJUSTED",
+                "symbol": symbol,
+                "apikey": self.api_key,
+                "outputsize": "compact",
+            }
+        )
+        return f"{self.base_url}?{params}"
+
+    def _fetch(self, symbol: str) -> Any:
+        url = self._build_url(symbol)
+        request = Request(
+            url,
+            headers={
+                "User-Agent": "StockTrak/1.0 (+https://github.com/StockTrak)",
+                "Accept": "application/json",
+            },
+        )
+        with self._opener(request) as response:
+            if getattr(response, "status", 200) != 200:
+                raise RuntimeError(f"Alpha Vantage HTTP {getattr(response, 'status', 'unknown')}")
+            data = response.read()
+            return json.loads(data.decode("utf-8"))
+
+    def _parse_quote(self, payload: Any) -> tuple[Decimal, dt.datetime] | None:
+        time_series = payload.get("Time Series (Daily)") if isinstance(payload, dict) else None
+        if not isinstance(time_series, dict):
+            if isinstance(payload, dict) and payload.get("Note"):
+                LOGGER.warning("Alpha Vantage rate limit or notice: %s", payload.get("Note"))
+            return None
+
+        latest_date: dt.datetime | None = None
+        latest_price: Decimal | None = None
+        for date_str, values in time_series.items():
+            try:
+                dt_value = dt.datetime.fromisoformat(date_str)
+            except ValueError:
+                continue
+            if latest_date is None or dt_value > latest_date:
+                close_val = values.get("4. close") if isinstance(values, dict) else None
+                if close_val is None:
+                    continue
+                try:
+                    latest_price = Decimal(str(close_val))
+                except (ArithmeticError, ValueError):
+                    continue
+                latest_date = dt_value
+
+        if latest_date is None or latest_price is None:
+            return None
+
+        return latest_price, latest_date.replace(tzinfo=dt.timezone.utc)
+
+    def get_last(self, symbols: list[str]) -> dict[str, PriceQuote]:
+        results: dict[str, PriceQuote] = {}
+        for symbol in symbols:
+            try:
+                payload = self._fetch(symbol)
+            except Exception as exc:  # noqa: BLE001
+                LOGGER.warning("Alpha Vantage request failed for %s: %s", symbol, exc)
+                continue
+
+            parsed = self._parse_quote(payload)
+            if not parsed:
+                LOGGER.debug("Alpha Vantage response missing price for %s", symbol)
+                continue
+
+            price, asof = parsed
+            results[symbol] = PriceQuote(
+                symbol=symbol,
+                price=price,
+                currency=self.currency,
+                asof=asof,
+                provider=self.provider_name,
+            )
+        return results
+
+
+__all__ = ["AlphaVantageProvider"]

--- a/portfolio_tool/providers/fallback_provider.py
+++ b/portfolio_tool/providers/fallback_provider.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import logging
+from collections import OrderedDict
+from typing import Dict
+
+from portfolio_tool.config import Config
+from portfolio_tool.core.pricing import PriceProvider, PriceQuote
+from portfolio_tool.providers.alphavantage_provider import AlphaVantageProvider
+from portfolio_tool.providers.marketindex_provider import MarketIndexProvider
+from portfolio_tool.providers.yahooquery_provider import YahooQueryProvider
+from portfolio_tool.providers.yfinance_provider import YFinanceProvider
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class FallbackPriceProvider:
+    """Coordinate primary and fallback providers with symbol normalisation."""
+
+    def __init__(
+        self,
+        cfg: Config,
+        providers: Dict[str, PriceProvider | None] | None = None,
+    ) -> None:
+        self.cfg = cfg
+        self._providers: Dict[str, PriceProvider | None] = providers or {}
+
+    # -- provider orchestration -------------------------------------------------
+    def _provider_order(self) -> list[str]:
+        names: list[str] = []
+        seen: set[str] = set()
+        for name in [self.cfg.pricing.provider_primary, *self.cfg.pricing.fallbacks]:
+            if name and name not in seen:
+                names.append(name)
+                seen.add(name)
+        return names
+
+    def _build_provider(self, name: str) -> PriceProvider | None:
+        match name:
+            case "yfinance":
+                return YFinanceProvider()
+            case "yahooquery":
+                return YahooQueryProvider()
+            case "marketindex":
+                if not self.cfg.pricing.include_marketindex:
+                    LOGGER.info(
+                        "Market Index fallback is disabled; set pricing.include_marketindex=true to enable"
+                    )
+                    return None
+                LOGGER.warning(
+                    "Using Market Index data API fallback. This is an undocumented endpoint and may change."
+                )
+                return MarketIndexProvider(base_currency=self.cfg.base_currency)
+            case "alphavantage":
+                api_key = self.cfg.alpha_vantage.api_key
+                if not api_key:
+                    LOGGER.info("Alpha Vantage fallback skipped: api key not configured")
+                    return None
+                return AlphaVantageProvider(api_key=api_key, currency=self.cfg.base_currency)
+            case _:
+                LOGGER.warning("Unknown price provider '%s'", name)
+                return None
+
+    def _get_provider(self, name: str) -> PriceProvider | None:
+        if name not in self._providers:
+            provider = self._build_provider(name)
+            if provider:
+                self._providers[name] = provider
+            else:
+                self._providers[name] = None  # cache skip
+        return self._providers.get(name)
+
+    # -- symbol handling --------------------------------------------------------
+    def _symbol_candidates(self, symbol: str) -> list[str]:
+        candidates: "OrderedDict[str, None]" = OrderedDict()
+        candidates[symbol] = None
+        if (
+            self.cfg.pricing.normalize_asx_suffix
+            and "." not in symbol
+            and self.cfg.timezone.lower().startswith("australia")
+        ):
+            candidates[f"{symbol}.AX"] = None
+        return list(candidates.keys())
+
+    # -- public api -------------------------------------------------------------
+    def get_last(self, symbols: list[str]) -> dict[str, PriceQuote]:
+        if not symbols:
+            return {}
+
+        normalised: dict[str, list[str]] = {s: self._symbol_candidates(s) for s in symbols}
+        results: dict[str, PriceQuote] = {}
+        remaining = set(symbols)
+
+        for provider_name in self._provider_order():
+            if not remaining:
+                break
+            provider = self._get_provider(provider_name)
+            if not provider:
+                continue
+
+            query_symbols = []
+            for symbol in remaining:
+                query_symbols.extend(normalised[symbol])
+            # preserve order while deduping
+            seen: set[str] = set()
+            ordered_query = [
+                sym for sym in query_symbols if not (sym in seen or seen.add(sym))
+            ]
+
+            try:
+                provider_results = provider.get_last(ordered_query)
+            except Exception as exc:  # noqa: BLE001
+                LOGGER.warning("Price provider %s failed: %s", provider_name, exc)
+                continue
+
+            for original_symbol in list(remaining):
+                for candidate in normalised[original_symbol]:
+                    quote = provider_results.get(candidate)
+                    if quote:
+                        if candidate != original_symbol:
+                            LOGGER.info(
+                                "Normalised %s -> %s via %s", original_symbol, candidate, provider_name
+                            )
+                        results[original_symbol] = PriceQuote(
+                            symbol=original_symbol,
+                            price=quote.price,
+                            currency=quote.currency,
+                            asof=quote.asof,
+                            provider=quote.provider,
+                        )
+                        remaining.remove(original_symbol)
+                        break
+
+        if remaining:
+            LOGGER.warning(
+                "No live price after fallbacks for: %s", ", ".join(sorted(remaining))
+            )
+
+        return results
+
+
+__all__ = ["FallbackPriceProvider"]

--- a/portfolio_tool/providers/marketindex_provider.py
+++ b/portfolio_tool/providers/marketindex_provider.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import datetime as dt
+import json
+import logging
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Callable
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+from portfolio_tool.core.pricing import PriceQuote
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _default_opener(request: Request):
+    return urlopen(request)  # noqa: S310 - read-only GET request
+
+
+@dataclass
+class MarketIndexProvider:
+    provider_name: str = "marketindex"
+    base_url: str = "https://data-api.marketindex.com.au"
+    base_currency: str = "AUD"
+    _opener: Callable[[Request], Any] = _default_opener
+
+    def _build_url(self, symbol: str) -> str:
+        params = urlencode({"search": symbol})
+        return f"{self.base_url.rstrip('/')}/v1/search?{params}"
+
+    def _fetch(self, symbol: str) -> Any:
+        url = self._build_url(symbol)
+        request = Request(
+            url,
+            headers={
+                "User-Agent": "StockTrak/1.0 (+https://github.com/StockTrak)",
+                "Accept": "application/json",
+            },
+        )
+        with self._opener(request) as response:
+            if getattr(response, "status", 200) != 200:
+                raise RuntimeError(f"Market Index HTTP {getattr(response, 'status', 'unknown')}")
+            payload = response.read()
+            return json.loads(payload.decode("utf-8"))
+
+    def _iter_dicts(self, payload: Any):
+        if isinstance(payload, dict):
+            yield payload
+            for value in payload.values():
+                yield from self._iter_dicts(value)
+        elif isinstance(payload, list):
+            for item in payload:
+                yield from self._iter_dicts(item)
+
+    def _extract_entry(self, symbol: str, payload: Any) -> dict[str, Any] | None:
+        symbol_upper = symbol.upper()
+        for entry in self._iter_dicts(payload):
+            entry_symbol = entry.get("symbol") or entry.get("code") or entry.get("ticker")
+            if entry_symbol and str(entry_symbol).upper() == symbol_upper:
+                return entry
+        return None
+
+    @staticmethod
+    def _parse_price(entry: dict[str, Any]) -> Decimal | None:
+        for key in ("last_price", "lastPrice", "price", "lastTradePrice", "closePrice"):
+            value = entry.get(key)
+            if value is not None:
+                try:
+                    return Decimal(str(value))
+                except (ArithmeticError, ValueError):
+                    continue
+        return None
+
+    @staticmethod
+    def _parse_datetime(entry: dict[str, Any]) -> dt.datetime | None:
+        for key in ("last_trade_time", "lastTradeDate", "lastUpdated", "priceDate"):
+            value = entry.get(key)
+            if not value:
+                continue
+            if isinstance(value, dt.datetime):
+                dt_value = value
+            else:
+                text = str(value)
+                if text.endswith("Z"):
+                    text = text.replace("Z", "+00:00")
+                try:
+                    dt_value = dt.datetime.fromisoformat(text)
+                except ValueError:
+                    continue
+            if dt_value.tzinfo is None:
+                dt_value = dt_value.replace(tzinfo=dt.timezone.utc)
+            return dt_value.astimezone(dt.timezone.utc)
+        return None
+
+    def get_last(self, symbols: list[str]) -> dict[str, PriceQuote]:
+        results: dict[str, PriceQuote] = {}
+        now = dt.datetime.now(dt.timezone.utc)
+        for symbol in symbols:
+            try:
+                payload = self._fetch(symbol)
+            except Exception as exc:  # noqa: BLE001
+                LOGGER.warning("Market Index lookup failed for %s: %s", symbol, exc)
+                continue
+
+            entry = self._extract_entry(symbol, payload)
+            if not entry:
+                LOGGER.debug("Market Index entry not found for %s", symbol)
+                continue
+
+            price = self._parse_price(entry)
+            if price is None:
+                LOGGER.debug("Market Index price missing for %s", symbol)
+                continue
+
+            asof = self._parse_datetime(entry) or now
+            results[symbol] = PriceQuote(
+                symbol=symbol,
+                price=price,
+                currency=self.base_currency,
+                asof=asof,
+                provider=self.provider_name,
+            )
+        return results
+
+
+__all__ = ["MarketIndexProvider"]

--- a/portfolio_tool/tests/test_pricing.py
+++ b/portfolio_tool/tests/test_pricing.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 
 from portfolio_tool.core.pricing import PriceQuote, PriceService
 from portfolio_tool.data import repo
+from portfolio_tool.providers.fallback_provider import FallbackPriceProvider
 
 
 class DummyProvider:
@@ -28,6 +29,41 @@ class DummyProvider:
             )
             for symbol in symbols
         }
+
+
+class StubProvider:
+    def __init__(self, name: str, prices: dict[str, str | Decimal]):
+        self.provider_name = name
+        self.prices = {k: Decimal(str(v)) for k, v in prices.items()}
+        self.calls: list[list[str]] = []
+
+    def get_last(self, symbols: list[str]) -> dict[str, PriceQuote]:
+        self.calls.append(list(symbols))
+        now = dt.datetime.now(dt.timezone.utc)
+        results: dict[str, PriceQuote] = {}
+        for symbol in symbols:
+            price = self.prices.get(symbol)
+            if price is None:
+                continue
+            results[symbol] = PriceQuote(
+                symbol=symbol,
+                price=price,
+                currency="AUD",
+                asof=now,
+                provider=self.provider_name,
+            )
+        return results
+
+
+class EmptyProvider:
+    provider_name = "empty"
+
+    def __init__(self):
+        self.calls: list[list[str]] = []
+
+    def get_last(self, symbols: list[str]) -> dict[str, PriceQuote]:
+        self.calls.append(list(symbols))
+        return {}
 
 
 def test_price_caching_respects_ttl(cfg, db):
@@ -54,3 +90,98 @@ def test_price_fallback_marks_stale(cfg, db):
         assert cached.is_stale is True
         assert quotes["BBB"].price == Decimal("50")
         assert provider.call_count == 2
+
+
+def test_fallback_normalises_asx_symbol(cfg):
+    cfg.timezone = "Australia/Sydney"
+    yfinance = StubProvider("yfinance", {"CSL.AX": "260.5"})
+    provider = FallbackPriceProvider(cfg, providers={"yfinance": yfinance})
+    quotes = provider.get_last(["CSL"])
+    assert "CSL" in quotes
+    assert quotes["CSL"].symbol == "CSL"
+    assert quotes["CSL"].provider == "yfinance"
+    assert any("CSL.AX" in call for call in yfinance.calls)
+
+
+def test_fallback_uses_yahooquery_when_primary_empty(cfg):
+    cfg.timezone = "Australia/Melbourne"
+    yfinance = EmptyProvider()
+    yahoo = StubProvider("yahooquery", {"ABC.AX": "12.34"})
+    provider = FallbackPriceProvider(
+        cfg,
+        providers={"yfinance": yfinance, "yahooquery": yahoo},
+    )
+    quotes = provider.get_last(["ABC"])
+    assert "ABC" in quotes
+    assert quotes["ABC"].provider == "yahooquery"
+    assert quotes["ABC"].price == Decimal("12.34")
+    assert yfinance.calls  # primary attempted first
+
+
+def test_marketindex_optional_fallback(cfg):
+    cfg.timezone = "Australia/Perth"
+    cfg.pricing.include_marketindex = True
+    yfinance = EmptyProvider()
+    yahoo = EmptyProvider()
+    market = StubProvider("marketindex", {"XYZ.AX": "7.89"})
+    provider = FallbackPriceProvider(
+        cfg,
+        providers={
+            "yfinance": yfinance,
+            "yahooquery": yahoo,
+            "marketindex": market,
+        },
+    )
+    quotes = provider.get_last(["XYZ"])
+    assert quotes["XYZ"].provider == "marketindex"
+    assert quotes["XYZ"].price == Decimal("7.89")
+
+
+def test_alphavantage_final_fallback(cfg):
+    cfg.timezone = "Australia/Brisbane"
+    cfg.alpha_vantage.api_key = "abc"
+    cfg.pricing.fallbacks = ["yahooquery", "marketindex", "alphavantage"]
+    yfinance = EmptyProvider()
+    yahoo = EmptyProvider()
+    alpha = StubProvider("alphavantage", {"ZZZ.AX": "15.55"})
+    provider = FallbackPriceProvider(
+        cfg,
+        providers={
+            "yfinance": yfinance,
+            "yahooquery": yahoo,
+            "alphavantage": alpha,
+        },
+    )
+    quotes = provider.get_last(["ZZZ"])
+    assert quotes["ZZZ"].provider == "alphavantage"
+    assert quotes["ZZZ"].price == Decimal("15.55")
+
+
+def test_total_failure_returns_stale_from_cache(cfg, db):
+    cfg.timezone = "Australia/Sydney"
+    provider = FallbackPriceProvider(
+        cfg,
+        providers={
+            "yfinance": EmptyProvider(),
+            "yahooquery": EmptyProvider(),
+            "marketindex": EmptyProvider(),
+            "alphavantage": EmptyProvider(),
+        },
+    )
+    service = PriceService(cfg, provider)
+    with db.session_scope() as session:
+        past = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=1)
+        repo.upsert_price(
+            session,
+            symbol="OLD",
+            price=Decimal("99.99"),
+            currency="AUD",
+            asof=past,
+            provider="seed",
+            ttl_expires_at=past,
+            is_stale=False,
+        )
+        quotes = service.get_quotes(session, ["OLD"])
+        cached = repo.get_price(session, "OLD")
+        assert cached.is_stale is True
+        assert quotes["OLD"].price == Decimal("99.99")

--- a/ui/textual_app.py
+++ b/ui/textual_app.py
@@ -28,8 +28,7 @@ from portfolio_tool.core.rules import generate_all_actionables
 from portfolio_tool.core.trades import TradeInput, record_trade
 from portfolio_tool.data import models, repo
 from portfolio_tool.data.repo import Database
-from portfolio_tool.providers.yfinance_provider import YFinanceProvider
-from portfolio_tool.providers.yahooquery_provider import YahooQueryProvider
+from portfolio_tool.providers.fallback_provider import FallbackPriceProvider
 
 from .views.actionables import ActionableAction, ActionablesView
 from .views.cgt_calendar import CGTCalendarView
@@ -474,9 +473,7 @@ class PortfolioApp(App):
 
 
 def _provider_for(cfg: Config):
-    if cfg.price_provider == "yahooquery":
-        return YahooQueryProvider()
-    return YFinanceProvider()
+    return FallbackPriceProvider(cfg)
 
 
 def build_services(cfg: Config, *, demo: bool = False) -> PortfolioServices:


### PR DESCRIPTION
## Summary
- add a configurable pricing provider chain with ASX symbol normalisation and fallback adapters for Market Index and Alpha Vantage
- update configuration, CLI/TUI wiring, and documentation to expose the new pricing options
- expand pricing tests to cover fallback scenarios and stale cache handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9f7a428148322b5da7c6bea0733ee