### PR TITLE
Add bootstrap launcher and PyInstaller build tooling

### DIFF
--- a/RUN.md
+++ b/RUN.md
@@ -1,0 +1,69 @@
+# Running the Portfolio Tool
+
+This project now ships with two easy ways to get started: a Python bootstrap
+script that manages its own virtual environment, and self-contained binaries
+built with PyInstaller.
+
+## Option 1 – Python bootstrap (recommended)
+
+1. Ensure Python 3.11 or newer is installed.
+2. Download or clone this repository.
+3. Double-click `run_portfolio.py` **or** execute it from a terminal:
+
+   ```bash
+   python run_portfolio.py
+   ```
+
+   The script will:
+
+   - create (or reuse) a virtual environment at `~/.portfolio_tool/.venv`
+     on macOS/Linux or `%APPDATA%\portfolio_tool\.venv` on Windows,
+   - install the required dependencies if they are missing, and
+   - launch the Textual UI (`portfolio ui`).
+
+4. To run a CLI command instead of the UI:
+
+   ```bash
+   python run_portfolio.py --cli "positions --export md out.md"
+   ```
+
+5. To rebuild the environment from scratch:
+
+   ```bash
+   python run_portfolio.py --reset-venv
+   ```
+
+6. Contributors can install the project in editable mode with:
+
+   ```bash
+   python run_portfolio.py --dev
+   ```
+
+## Option 2 – Stand-alone executable
+
+1. Download the appropriate binary from `dist/`:
+
+   - Windows: `dist/portfolio.exe`
+   - macOS/Linux: `dist/portfolio`
+
+2. Run the executable directly. It bundles Python and all dependencies, so no
+   additional setup is required.
+
+## Troubleshooting
+
+- **UI does not start:** try the CLI instead to check for errors:
+
+  ```bash
+  python run_portfolio.py --cli "positions"
+  ```
+
+- **Resetting the environment:** `python run_portfolio.py --reset-venv`
+  deletes and recreates the managed virtual environment.
+
+- **Windows SmartScreen:** Windows may warn about unknown publishers. Choose
+  “More info” → “Run anyway” to continue.
+
+- **Manual launch:** If the bootstrap fails, activate the virtual environment
+  (`source ~/.portfolio_tool/.venv/bin/activate` or
+  `%APPDATA%\portfolio_tool\.venv\Scripts\activate`) and run
+  `python -m portfolio_tool ui`.

--- a/build_exe.py
+++ b/build_exe.py
@@ -1,0 +1,117 @@
+"""Build a one-file executable for the Portfolio Tool using PyInstaller."""
+
+from __future__ import annotations
+
+import os
+import platform
+import tempfile
+from pathlib import Path
+
+import PyInstaller.__main__
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python <3.11
+    import tomli as tomllib  # type: ignore
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent
+
+HIDDEN_IMPORTS = [
+    "pandas._libs.tslibs.timedeltas",
+    "pandas._libs.tslibs.nattype",
+    "pandas._libs.tslibs.np_datetime",
+    "dateutil.tz",
+    "zoneinfo",
+    "yfinance",
+    "yahooquery",
+    "sqlalchemy.dialects.sqlite",
+]
+
+
+def read_version() -> str:
+    data = tomllib.loads((PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    return data["project"]["version"]
+
+
+def build_version_file(version: str) -> Path:
+    major, minor, patch, *_ = (version.split(".") + ["0", "0"])[:4]
+    version_tuple = ", ".join([major, minor, patch, "0"])
+    template = f"""
+# UTF-8
+#
+VSVersionInfo(
+  ffi=FixedFileInfo(
+    filevers=({version_tuple}),
+    prodvers=({version_tuple}),
+    mask=0x3f,
+    flags=0x0,
+    OS=0x40004,
+    fileType=0x1,
+    subtype=0x0,
+    date=(0, 0)
+  ),
+  kids=[
+    StringFileInfo([
+      StringTable(
+        "040904B0",
+        [
+          StringStruct("CompanyName", "StockTrak"),
+          StringStruct("FileDescription", "Portfolio Tool"),
+          StringStruct("FileVersion", "{version}"),
+          StringStruct("InternalName", "portfolio"),
+          StringStruct("OriginalFilename", "portfolio.exe"),
+          StringStruct("ProductName", "Portfolio Tool"),
+          StringStruct("ProductVersion", "{version}")
+        ]
+      )
+    ]),
+    VarFileInfo([VarStruct("Translation", [1033, 1200])])
+  ]
+)
+"""
+    handle = tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False, suffix=".txt")
+    handle.write(template.strip())
+    handle.flush()
+    handle.close()
+    return Path(handle.name)
+
+
+def find_data_files() -> list[str]:
+    entries: list[str] = []
+    try:
+        import tzdata  # type: ignore
+    except ImportError:
+        tzdata_path = None
+    else:
+        tzdata_path = Path(tzdata.__file__).resolve().parent
+    if tzdata_path and tzdata_path.exists():
+        entries.append(f"{tzdata_path}{os.pathsep}tzdata")
+    return entries
+
+
+def main() -> None:
+    version = read_version()
+    version_file = build_version_file(version)
+    args = ["--clean", "--onefile", "--name", "portfolio"]
+    for hidden in HIDDEN_IMPORTS:
+        args.extend(["--hidden-import", hidden])
+    for data_entry in find_data_files():
+        args.extend(["--add-data", data_entry])
+
+    icon_path = PROJECT_ROOT / "ui" / "icon.ico"
+    if icon_path.exists():
+        args.extend(["--icon", str(icon_path)])
+
+    if platform.system() == "Windows":
+        args.extend(["--version-file", str(version_file)])
+
+    args.append(str(PROJECT_ROOT / "entry.py"))
+    try:
+        PyInstaller.__main__.run(args)
+    finally:
+        Path(version_file).unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/entry.py
+++ b/entry.py
@@ -1,0 +1,17 @@
+"""Entry point used by PyInstaller one-file builds."""
+
+from __future__ import annotations
+
+import sys
+
+
+def main() -> None:
+    from portfolio_tool.__main__ import app
+
+    if len(sys.argv) == 1:
+        sys.argv.append("ui")
+    app()
+
+
+if __name__ == "__main__":
+    main()

--- a/portfolio_tool/tests/test_run_portfolio.py
+++ b/portfolio_tool/tests/test_run_portfolio.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from pathlib import Path
+
+import run_portfolio
+
+
+def _setup_home(monkeypatch, tmp_path: Path) -> Path:
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.delenv("APPDATA", raising=False)
+    return home
+
+
+def test_main_creates_venv_and_installs(tmp_path, monkeypatch):
+    home = _setup_home(monkeypatch, tmp_path)
+
+    venv_path = home / ".portfolio_tool" / ".venv"
+
+    def fake_create(path: Path) -> None:
+        bin_dir = path / "bin"
+        bin_dir.mkdir(parents=True, exist_ok=True)
+        (bin_dir / "python").write_text("", encoding="utf-8")
+
+    monkeypatch.setattr(run_portfolio, "create_virtualenv", fake_create)
+
+    commands: list[list[str]] = []
+
+    def fake_run(command, *, capture_output=False):  # noqa: ARG001
+        commands.append(list(command))
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(run_portfolio, "run_command", fake_run)
+
+    exit_code = run_portfolio.main([])
+    assert exit_code == 0
+
+    marker = venv_path / run_portfolio.MARKER_NAME
+    assert marker.exists()
+    requirements, _ = run_portfolio.load_requirements()
+    expected_signature = run_portfolio.requirements_signature(requirements)
+    assert marker.read_text(encoding="utf-8") == expected_signature
+
+    assert commands[0][2] == "pip"
+    assert commands[-1][-2:] == ["portfolio_tool", "ui"]
+
+
+def test_main_skips_install_when_marker_matches(tmp_path, monkeypatch):
+    home = _setup_home(monkeypatch, tmp_path)
+    venv_path = home / ".portfolio_tool" / ".venv"
+    bin_dir = venv_path / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    python_exe = bin_dir / "python"
+    python_exe.write_text("", encoding="utf-8")
+
+    requirements, _ = run_portfolio.load_requirements()
+    signature = run_portfolio.requirements_signature(requirements)
+    (venv_path / run_portfolio.MARKER_NAME).write_text(signature, encoding="utf-8")
+
+    def fail_create(path):  # noqa: ARG001
+        raise AssertionError("virtual environment should not be recreated")
+
+    monkeypatch.setattr(run_portfolio, "create_virtualenv", fail_create)
+
+    commands: list[list[str]] = []
+
+    def fake_run(command, *, capture_output=False):  # noqa: ARG001
+        commands.append(list(command))
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(run_portfolio, "run_command", fake_run)
+
+    exit_code = run_portfolio.main([])
+    assert exit_code == 0
+    assert commands == [[str(python_exe), "-m", "portfolio_tool", "ui"]]
+
+
+def test_main_runs_cli_command(tmp_path, monkeypatch):
+    home = _setup_home(monkeypatch, tmp_path)
+    venv_path = home / ".portfolio_tool" / ".venv"
+    bin_dir = venv_path / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    python_exe = bin_dir / "python"
+    python_exe.write_text("", encoding="utf-8")
+
+    requirements, _ = run_portfolio.load_requirements()
+    signature = run_portfolio.requirements_signature(requirements)
+    (venv_path / run_portfolio.MARKER_NAME).write_text(signature, encoding="utf-8")
+
+    commands: list[list[str]] = []
+
+    def fake_run(command, *, capture_output=False):  # noqa: ARG001
+        commands.append(list(command))
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr(run_portfolio, "run_command", fake_run)
+    monkeypatch.setattr(run_portfolio, "create_virtualenv", lambda path: None)
+
+    exit_code = run_portfolio.main(["--cli", "positions --export md out.md"])
+    assert exit_code == 0
+    assert commands == [
+        [
+            str(python_exe),
+            "-m",
+            "portfolio_tool",
+            "positions",
+            "--export",
+            "md",
+            "out.md",
+        ]
+    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,13 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-cov", "freezegun", "python-dateutil"]
+dev = [
+    "pytest",
+    "pytest-cov",
+    "freezegun",
+    "python-dateutil",
+    "pyinstaller>=6",
+]
 
 [project.scripts]
 portfolio = "portfolio_tool.__main__:app"

--- a/run_portfolio.py
+++ b/run_portfolio.py
@@ -1,0 +1,289 @@
+"""Bootstrap launcher for the portfolio tool.
+
+This script creates (or reuses) a dedicated virtual environment, installs
+the project's dependencies if required, and launches the Portfolio Tool UI
+by default.  It is intended to be a single file that can be double-clicked
+or executed with ``python run_portfolio.py`` on systems with Python 3.11+.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import platform
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parent
+LOCKFILE = REPO_ROOT / "requirements-lock.txt"
+MARKER_NAME = ".requirements_hash"
+
+REQUIREMENTS: Sequence[str] = (
+    "typer>=0.12",
+    "rich>=13",
+    "textual>=0.60",
+    "sqlalchemy>=2.0",
+    "alembic>=1.13",
+    "pydantic>=2.7",
+    "yfinance>=0.2",
+    "yahooquery>=2.3",
+    "tzdata; platform_system=='Windows'",
+)
+
+
+class LaunchError(RuntimeError):
+    """Raised when bootstrapping fails."""
+
+
+def parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Launch the Portfolio Tool")
+    parser.add_argument(
+        "--cli",
+        metavar="ARGS",
+        help="Run a CLI command instead of launching the UI",
+    )
+    parser.add_argument(
+        "--reset-venv",
+        action="store_true",
+        help="Rebuild the virtual environment before launching",
+    )
+    parser.add_argument(
+        "--dev",
+        action="store_true",
+        help="Install the project in editable mode (for contributors)",
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def ensure_python_version() -> None:
+    if sys.version_info < (3, 11):
+        raise LaunchError(
+            "Python 3.11 or newer is required. "
+            "Please install a compatible version and try again."
+        )
+
+
+def resolve_base_dir() -> Path:
+    system = platform.system()
+    if system == "Windows":
+        appdata = os.environ.get("APPDATA")
+        if appdata:
+            base = Path(appdata) / "portfolio_tool"
+        else:
+            base = Path(os.path.expanduser("~")) / ".portfolio_tool"
+    else:
+        base = Path(os.path.expanduser("~")) / ".portfolio_tool"
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def venv_path_for_platform() -> Path:
+    return resolve_base_dir() / ".venv"
+
+
+def get_venv_python(venv_path: Path) -> Path:
+    if platform.system() == "Windows":
+        return venv_path / "Scripts" / "python.exe"
+    return venv_path / "bin" / "python"
+
+
+def create_virtualenv(venv_path: Path) -> None:
+    print("Creating virtual environment…")
+    parent = venv_path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    import venv
+
+    builder = venv.EnvBuilder(with_pip=True)
+    builder.create(str(venv_path))
+
+
+def remove_virtualenv(venv_path: Path) -> None:
+    if venv_path.exists():
+        print("Removing existing virtual environment…")
+        shutil.rmtree(venv_path)
+
+
+def run_command(command: Sequence[str], *, capture_output: bool = False) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(command),
+        check=True,
+        text=True,
+        capture_output=capture_output,
+    )
+
+
+def requirements_from_lockfile(lockfile: Path) -> List[str]:
+    requirements: List[str] = []
+    for line in lockfile.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        requirements.append(stripped)
+    return requirements
+
+
+def load_requirements() -> tuple[List[str], Path | None]:
+    if LOCKFILE.exists():
+        return requirements_from_lockfile(LOCKFILE), LOCKFILE
+    return list(REQUIREMENTS), None
+
+
+def requirements_signature(requirements: Iterable[str]) -> str:
+    combined = "\n".join(requirements)
+    return hashlib.sha256(combined.encode("utf-8")).hexdigest()
+
+
+def pip_base_command(python_executable: Path) -> list[str]:
+    return [
+        str(python_executable),
+        "-m",
+        "pip",
+        "--disable-pip-version-check",
+        "--no-input",
+    ]
+
+
+def upgrade_pip(python_executable: Path) -> None:
+    print("Upgrading pip…")
+    run_command(pip_base_command(python_executable) + ["install", "--quiet", "--upgrade", "pip"])
+
+
+def install_requirements(
+    python_executable: Path,
+    requirements: Sequence[str],
+    *,
+    requirement_file: Path | None,
+) -> None:
+    print("Installing dependencies…")
+    if requirement_file is not None:
+        command = pip_base_command(python_executable) + [
+            "install",
+            "--quiet",
+            "--upgrade",
+            "-r",
+            str(requirement_file),
+        ]
+    else:
+        command = (
+            pip_base_command(python_executable)
+            + ["install", "--quiet", "--upgrade"]
+            + list(requirements)
+        )
+    run_command(command)
+
+
+def install_editable(python_executable: Path) -> None:
+    print("Installing portfolio-tool in editable mode…")
+    command = pip_base_command(python_executable) + [
+        "install",
+        "--quiet",
+        "--upgrade",
+        "-e",
+        str(REPO_ROOT),
+    ]
+    run_command(command)
+
+
+def marker_path(venv_path: Path) -> Path:
+    return venv_path / MARKER_NAME
+
+
+def ensure_dependencies(
+    python_executable: Path,
+    requirements: Sequence[str],
+    requirement_file: Path | None,
+    *,
+    venv_path: Path,
+    force: bool = False,
+) -> None:
+    signature = requirements_signature(requirements)
+    marker = marker_path(venv_path)
+    need_install = force or not marker.exists() or marker.read_text(encoding="utf-8") != signature
+    if need_install:
+        upgrade_pip(python_executable)
+        install_requirements(python_executable, requirements, requirement_file=requirement_file)
+        marker.write_text(signature, encoding="utf-8")
+    else:
+        print("Dependencies already satisfied.")
+
+
+def launch_application(python_executable: Path, cli_args: Sequence[str] | None) -> None:
+    if cli_args:
+        command = [str(python_executable), "-m", "portfolio_tool"] + list(cli_args)
+        print("Running CLI command…")
+    else:
+        command = [str(python_executable), "-m", "portfolio_tool", "ui"]
+        print("Launching Portfolio UI…")
+    run_command(command)
+
+
+def prepare_venv(reset: bool) -> tuple[Path, Path]:
+    venv_path = venv_path_for_platform()
+    if reset:
+        remove_virtualenv(venv_path)
+
+    python_executable = get_venv_python(venv_path)
+    if not python_executable.exists():
+        create_virtualenv(venv_path)
+    python_executable = get_venv_python(venv_path)
+    if not python_executable.exists():
+        raise LaunchError("Failed to locate Python inside the virtual environment.")
+    return venv_path, python_executable
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    try:
+        args = parse_args(argv)
+        ensure_python_version()
+        venv_path, python_executable = prepare_venv(args.reset_venv)
+
+        requirements, requirement_file = load_requirements()
+        force_install = args.reset_venv or not marker_path(venv_path).exists()
+        ensure_dependencies(
+            python_executable,
+            requirements,
+            requirement_file=requirement_file,
+            venv_path=venv_path,
+            force=force_install,
+        )
+
+        if args.dev:
+            install_editable(python_executable)
+
+        cli_args: Sequence[str] | None
+        if args.cli:
+            cli_args = shlex.split(args.cli)
+        else:
+            cli_args = None
+        launch_application(python_executable, cli_args)
+        return 0
+    except LaunchError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        print(
+            "You can try running 'python -m portfolio_tool ui' from the project "
+            "directory once dependencies are installed.",
+            file=sys.stderr,
+        )
+        return 1
+    except subprocess.CalledProcessError as exc:
+        print("A command failed while bootstrapping the application.", file=sys.stderr)
+        if exc.stdout:
+            print(exc.stdout, file=sys.stderr)
+        if exc.stderr:
+            print(exc.stderr, file=sys.stderr)
+        print(
+            "You can try running the reported command manually inside the "
+            "virtual environment to diagnose the problem.",
+            file=sys.stderr,
+        )
+        return exc.returncode or 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a standalone `run_portfolio.py` launcher that bootstraps a managed venv and starts the UI or CLI
- add PyInstaller entry/build scripts plus developer docs for running the tool and binaries
- cover the launcher with smoke tests and include PyInstaller in dev dependencies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9fa9d621c8322bbbe3ada2a56502e