### PR TITLE
Fix price status lookup in TUI

### DIFF
--- a/ui/textual_app.py
+++ b/ui/textual_app.py
@@ -198,9 +198,8 @@ class PortfolioServices:
 
     def get_price_status(self) -> PriceStatus:
         with self._session() as session:
-            latest = session.scalars(
-                select(models.PriceCache).order_by(models.PriceCache.asof.desc()).limit(1)
-            ).first()
+            stmt = select(models.PriceCache).order_by(models.PriceCache.asof.desc())
+            latest = session.scalars(stmt).first()
             if latest:
                 return PriceStatus(asof=latest.asof, stale=bool(latest.is_stale))
             return PriceStatus(asof=None, stale=self.cfg.offline_mode)


### PR DESCRIPTION
## Summary
- avoid calling Select.limit() when reading the latest price cache entry

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daf31bc3108322a4a3f91cd33680ae