### PR TITLE
Handle missing Textual dependency in tests

### DIFF
--- a/ui/textual_app.py
+++ b/ui/textual_app.py
@@ -45,17 +45,18 @@ except ModuleNotFoundError as exc:  # pragma: no cover - textual optional for te
 else:
     TEXTUAL_AVAILABLE = True
 
-from .views.actionables import ActionableAction, ActionablesView
-from .views.cgt_calendar import CGTCalendarView
-from .views.dashboard import DashboardView
-from .views.lots import LotSelected, LotsView
-from .views.positions import PositionSelected, PositionsView
-from .widgets.add_trade_modal import AddTradeModal
-from .widgets.header import HeaderWidget
-from .widgets.lot_detail import LotDetailWidget
-from .widgets.sidebar import Sidebar
-from .widgets.symbol_detail import SymbolDetailWidget
-from .widgets.toasts import ToastManager
+if TYPE_CHECKING:  # pragma: no cover - import for type checking only
+    from .views.actionables import ActionableAction, ActionablesView
+    from .views.cgt_calendar import CGTCalendarView
+    from .views.dashboard import DashboardView
+    from .views.lots import LotSelected, LotsView
+    from .views.positions import PositionSelected, PositionsView
+    from .widgets.add_trade_modal import AddTradeModal
+    from .widgets.header import HeaderWidget
+    from .widgets.lot_detail import LotDetailWidget
+    from .widgets.sidebar import Sidebar
+    from .widgets.symbol_detail import SymbolDetailWidget
+    from .widgets.toasts import ToastManager
 
 
 @dataclass
@@ -224,6 +225,18 @@ class PortfolioServices:
 
 
 if TEXTUAL_AVAILABLE:
+
+    from .views.actionables import ActionableAction, ActionablesView
+    from .views.cgt_calendar import CGTCalendarView
+    from .views.dashboard import DashboardView
+    from .views.lots import LotSelected, LotsView
+    from .views.positions import PositionSelected, PositionsView
+    from .widgets.add_trade_modal import AddTradeModal
+    from .widgets.header import HeaderWidget
+    from .widgets.lot_detail import LotDetailWidget
+    from .widgets.sidebar import Sidebar
+    from .widgets.symbol_detail import SymbolDetailWidget
+    from .widgets.toasts import ToastManager
 
     class TextPrompt(ModalScreen[str | None]):
         def __init__(self, title: str, prompt: str, default: str = "") -> None:


### PR DESCRIPTION
## Summary
- defer importing Textual UI view and widget modules until the Textual dependency is available
- keep type checking support by moving the imports behind TYPE_CHECKING guards

## Testing
- pytest tests/test_price_status.py

------
https://chatgpt.com/codex/tasks/task_e_68db17517e8c8322b239cb42e972cec7