### PR TITLE
Add diagnostics and shared database initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ portfolio positions
 
 All application data (configuration, SQLite database, and markdown exports) lives under `~/.portfolio_tool` by default. Override the location via the `PORTFOLIO_TOOL_HOME` environment variable or by passing `--config` to any command.
 
+## Quick Troubleshooting
+
+### If the UI is empty or shows Offline
+1) Run `portfolio status` — check DB path and row counts.
+2) If Trades>0 and Lots=0, re-save a BUY (lot should be created) or file a bug.
+3) Run `portfolio price-refresh CSL.AX` to seed a fresh price.
+4) Ensure `offline_mode=false` in `~/.portfolio_tool/config.toml`.
+
 ## Features
 
 - Manual trade entry (buy or sell) with timezone-aware timestamps, fees, and optional notes.

--- a/portfolio_tool/core/diagnostics.py
+++ b/portfolio_tool/core/diagnostics.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from portfolio_tool.config import Config
+from portfolio_tool.core.pricing import PriceService
+from portfolio_tool.data import models
+
+PriceReason = Literal["no_prices", "stale", "offline_mode", "ok"]
+
+
+@dataclass
+class PriceSnapshot:
+    symbol: str
+    asof: Optional[dt.datetime]
+    is_stale: bool
+
+
+@dataclass
+class PortfolioDiagnostics:
+    db_path: Path
+    db_exists: bool
+    trade_count: int
+    lot_count: int
+    price_count: int
+    actionable_count: int
+    latest_price: PriceSnapshot | None
+    offline_mode: bool
+    price_provider: str
+    price_ttl_minutes: int
+
+
+def collect_diagnostics(cfg: Config, session: Session) -> PortfolioDiagnostics:
+    def _count(model) -> int:
+        stmt = select(model)
+        return len(list(session.scalars(stmt)))
+
+    trade_count = _count(models.Trade)
+    lot_count = _count(models.Lot)
+    price_count = _count(models.PriceCache)
+    actionable_count = _count(models.Actionable)
+    latest_row = (
+        session.execute(
+            select(models.PriceCache).order_by(models.PriceCache.asof.desc()).limit(1)
+        )
+        .scalars()
+        .first()
+    )
+    latest_price = None
+    if latest_row:
+        latest_price = PriceSnapshot(
+            symbol=latest_row.symbol,
+            asof=PriceService._ensure_aware(latest_row.asof),
+            is_stale=bool(getattr(latest_row, "is_stale", False)),
+        )
+    return PortfolioDiagnostics(
+        db_path=cfg.db_path,
+        db_exists=cfg.db_path.exists(),
+        trade_count=int(trade_count),
+        lot_count=int(lot_count),
+        price_count=int(price_count),
+        actionable_count=int(actionable_count),
+        latest_price=latest_price,
+        offline_mode=cfg.offline_mode,
+        price_provider=cfg.price_provider,
+        price_ttl_minutes=cfg.price_ttl_minutes,
+    )
+
+
+def determine_price_status(diagnostics: PortfolioDiagnostics) -> tuple[Optional[dt.datetime], PriceReason]:
+    latest = diagnostics.latest_price
+    if diagnostics.offline_mode:
+        asof = latest.asof if latest else None
+        return asof, "offline_mode"
+    if diagnostics.price_count == 0 or latest is None:
+        return None, "no_prices"
+    if latest.is_stale:
+        return latest.asof, "stale"
+    return latest.asof, "ok"
+
+
+__all__ = [
+    "PriceReason",
+    "PriceSnapshot",
+    "PortfolioDiagnostics",
+    "collect_diagnostics",
+    "determine_price_status",
+]

--- a/portfolio_tool/data/init_db.py
+++ b/portfolio_tool/data/init_db.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import create_engine
+
+from portfolio_tool.config import get_db_url
+from portfolio_tool.data import models
+
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from sqlalchemy.engine import Engine
+else:  # pragma: no cover - fallback for stubbed SQLAlchemy
+    Engine = Any
+
+
+def ensure_db() -> Engine:
+    engine = create_engine(
+        get_db_url(), connect_args={"check_same_thread": False}
+    )
+    models.Base.metadata.create_all(engine)
+    return engine
+
+
+__all__ = ["ensure_db"]

--- a/portfolio_tool/data/repo.py
+++ b/portfolio_tool/data/repo.py
@@ -6,19 +6,22 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Optional
 
-from sqlalchemy import create_engine, func, select
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session, sessionmaker
 
-from portfolio_tool.config import Config, ensure_app_dirs
 from . import models
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from sqlalchemy.engine import Engine
+else:  # pragma: no cover - fallback for stubbed SQLAlchemy
+    Engine = Any
 
 
 class Database:
-    def __init__(self, cfg: Config):
-        ensure_app_dirs(cfg)
-        self.engine = create_engine(
-            f"sqlite:///{cfg.db_path}", connect_args={"check_same_thread": False}
-        )
+    def __init__(self, engine: Engine):
+        self.engine = engine
         self.Session = sessionmaker(self.engine, expire_on_commit=False)
 
     def create_all(self):

--- a/portfolio_tool/tests/conftest.py
+++ b/portfolio_tool/tests/conftest.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from sqlalchemy import create_engine
 
 from portfolio_tool.config import Config
+from portfolio_tool.data import models
 from portfolio_tool.data.repo import Database
 
 
@@ -19,9 +21,9 @@ def cfg(tmp_path: Path) -> Config:
 
 @pytest.fixture
 def db(cfg: Config) -> Database:
-    database = Database(cfg)
-    database.create_all()
-    return database
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    models.Base.metadata.create_all(engine)
+    return Database(engine)
 
 
 @pytest.fixture

--- a/portfolio_tool/tests/test_lots.py
+++ b/portfolio_tool/tests/test_lots.py
@@ -97,3 +97,15 @@ def test_specific_id_matching(cfg, db):
         )
         disposal = session.scalars(select(models.Disposal)).one()
         assert disposal.lot_id == target_lot.id
+
+
+def test_buy_creates_lot(cfg, db):
+    trade_dt = dt.datetime(2024, 1, 15, tzinfo=dt.timezone.utc)
+    with db.session_scope() as session:
+        trade = record_trade(session, cfg, _trade(trade_dt, "5", "100"))
+        lots = list(session.scalars(select(models.Lot)))
+        assert len(lots) == 1
+        lot = lots[0]
+        assert Decimal(lot.qty_remaining) == trade.qty
+        assert lot.threshold_date is not None
+        assert lot.trade_id == trade.id

--- a/portfolio_tool/tests/test_ui_smoke.py
+++ b/portfolio_tool/tests/test_ui_smoke.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import datetime as dt
 
 import pytest
+from sqlalchemy import create_engine
 
 textual = pytest.importorskip("textual")
 
 from portfolio_tool.config import Config
 from portfolio_tool.core.pricing import PriceQuote, PriceService
+from portfolio_tool.data import models
 from portfolio_tool.data.repo import Database
 
 from ui.textual_app import PortfolioApp, PortfolioServices
@@ -22,11 +24,11 @@ class DummyProvider:
         }
 
 
-def test_portfolio_app_instantiation(tmp_path):
+def test_portfolio_app_instantiation():
     cfg = Config()
-    cfg.db_path = tmp_path / "test.db"
-    db = Database(cfg)
-    db.create_all()
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    models.Base.metadata.create_all(engine)
+    db = Database(engine)
     pricing = PriceService(cfg, DummyProvider())
     services = PortfolioServices(cfg, db, pricing)
     app = PortfolioApp(services)

--- a/tests/test_bootstrap_status.py
+++ b/tests/test_bootstrap_status.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import datetime as dt
+import re
+from decimal import Decimal
+
+from typer.testing import CliRunner
+from sqlalchemy import select
+
+from portfolio_tool.__main__ import app
+from portfolio_tool.config import load_config
+from portfolio_tool.core.trades import TradeInput, record_trade
+from portfolio_tool.data import models
+from portfolio_tool.data.init_db import ensure_db
+from portfolio_tool.data.repo import Database
+
+
+def test_bootstrap_status(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    engine = ensure_db()
+    tables = {
+        getattr(model, "__tablename__", model.__name__.lower())
+        for model in engine.store.keys()
+    }
+    for expected in {"trades", "lots", "price_cache", "actionables"}:
+        assert expected in tables
+
+    cfg = load_config()
+    db = Database(engine)
+
+    trade_input = TradeInput(
+        side="BUY",
+        symbol="CSL.AX",
+        dt=dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc),
+        qty=Decimal("1"),
+        price=Decimal("100"),
+        fees=Decimal("0"),
+    )
+
+    with db.session_scope() as session:
+        record_trade(session, cfg, trade_input)
+
+    with db.session_scope() as session:
+        lots = list(session.scalars(select(models.Lot)))
+        assert len(lots) == 1
+
+    monkeypatch.setattr("portfolio_tool.__main__.ensure_db", lambda: engine)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["status"])
+    assert result.exit_code == 0
+    trades_match = re.search(r"Trades\s+[^0-9]*(\d+)", result.output)
+    lots_match = re.search(r"Lots\s+[^0-9]*(\d+)", result.output)
+    assert trades_match and int(trades_match.group(1)) > 0
+    assert lots_match and int(lots_match.group(1)) > 0

--- a/tests/test_price_status.py
+++ b/tests/test_price_status.py
@@ -63,6 +63,7 @@ def test_get_price_status_no_rows(mem_session):
     assert isinstance(status, PriceStatus)
     assert status.asof is None
     assert status.stale is True
+    assert status.reason == "no_prices"
 
 
 def test_get_price_status_with_row(mem_session):
@@ -87,3 +88,4 @@ def test_get_price_status_with_row(mem_session):
 
     assert status.asof == now
     assert status.stale is False
+    assert status.reason == "ok"

--- a/ui/widgets/header.py
+++ b/ui/widgets/header.py
@@ -19,7 +19,12 @@ class HeaderWidget(Widget):
         self.cfg = cfg
         from ..textual_app import PriceStatus  # Local import to avoid cycle
 
-        self._status = PriceStatus(asof=None, stale=cfg.offline_mode)
+        default_reason = "offline_mode" if cfg.offline_mode else "no_prices"
+        self._status = PriceStatus(
+            asof=None,
+            stale=cfg.offline_mode or default_reason != "ok",
+            reason=default_reason,
+        )
 
     def update_status(self, status: "PriceStatus") -> None:
         self._status = status
@@ -32,6 +37,6 @@ class HeaderWidget(Widget):
             parts.append(f"Prices: {timestamp}")
         else:
             parts.append("Prices: —")
-        if self._status.stale:
-            parts.append("[O] Offline")
+        if self._status.reason != "ok":
+            parts.append(f"[O] Offline [{self._status.reason}]")
         return Text(" | ".join(parts), style="bold white")


### PR DESCRIPTION
## Summary
- centralize database path resolution and auto-initialize the SQLite store for CLI and UI startup
- add a reusable diagnostics helper with a new `portfolio status` command and enhanced price refresh output
- surface diagnostics in the Textual UI, show offline reasons, and guard BUY lots with regression tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db1c147ae0832282398f7543f5e000