### PR TITLE
Provide textual UI stub when dependencies missing

### DIFF
--- a/ui/textual_app.py
+++ b/ui/textual_app.py
@@ -591,6 +591,21 @@ if TEXTUAL_AVAILABLE:
 
 else:
 
+    class PortfolioApp:  # pragma: no cover - textual optional
+        """Placeholder PortfolioApp used when textual dependencies are unavailable."""
+
+        def __init__(self, *_: object, **__: object) -> None:
+            raise ModuleNotFoundError(
+                "The textual UI requires optional dependencies 'rich' and 'textual'. "
+                "Install the project with the 'ui' extras to enable this feature."
+            ) from _TEXTUAL_IMPORT_ERROR
+
+        def run(self) -> None:
+            raise ModuleNotFoundError(
+                "The textual UI requires optional dependencies 'rich' and 'textual'. "
+                "Install the project with the 'ui' extras to enable this feature."
+            ) from _TEXTUAL_IMPORT_ERROR
+
     def run(argv: Optional[list[str]] = None) -> None:  # pragma: no cover - defensive
         raise ModuleNotFoundError(
             "The textual UI requires optional dependencies 'rich' and 'textual'. "


### PR DESCRIPTION
## Summary
- add a placeholder PortfolioApp so the CLI can import without textual dependencies
- ensure both the stub constructor and run method raise a clear ModuleNotFoundError guiding users to install optional extras

## Testing
- pytest tests/test_bootstrap_status.py

------
https://chatgpt.com/codex/tasks/task_e_68db24ee72608322875d271554969b6c