### PR TITLE
Fix row key lookup for Textual DataTable API changes

### DIFF
--- a/ui/views/actionables.py
+++ b/ui/views/actionables.py
@@ -49,7 +49,9 @@ class ActionablesView(DataTable):
     def on_key(self, event: events.Key) -> None:  # pragma: no cover - Textual callback
         if not self._rows:
             return
-        row_key = self.get_row_key(self.cursor_row)
+        if not self.is_valid_row_index(self.cursor_row):
+            return
+        row_key = self.ordered_rows[self.cursor_row].key
         if not row_key:
             return
         actionable_id = int(row_key)

--- a/ui/views/positions.py
+++ b/ui/views/positions.py
@@ -91,6 +91,8 @@ class PositionsView(DataTable):
             self.post_message(PositionSelected(str(event.row_key)))
 
     def watch_cursor_row(self, value: int) -> None:  # pragma: no cover - Textual callback
-        row_key = self.get_row_key(value)
+        if not self.is_valid_row_index(value):
+            return
+        row_key = self.ordered_rows[value].key
         if row_key is not None:
             self.post_message(PositionSelected(str(row_key)))


### PR DESCRIPTION
## Summary
- guard against invalid cursor rows before acting on actionable entries
- fetch row keys via ordered_rows to stay compatible with the current Textual API

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db28ff4de8832289567d81d19a4c03