### PR TITLE
Add data refresh events and improve TUI navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ All application data (configuration, SQLite database, and markdown exports) live
 3) Run `portfolio price-refresh CSL.AX` to seed a fresh price.
 4) Ensure `offline_mode=false` in `~/.portfolio_tool/config.toml`.
 
+### TUI Troubleshooting
+
+- Run with: `TEXTUAL_LOG=debug TEXTUAL_DEVTOOLS=1 portfolio ui`
+- Use keys 1–5 to switch between Dashboard, Positions, Lots, CGT Calendar, and Actionables.
+- After adding a trade, you should see “Trade saved; refreshing…” toast and refreshed rows.
+
 ## Features
 
 - Manual trade entry (buy or sell) with timezone-aware timestamps, fees, and optional notes.

--- a/tests/test_trade_lot_creation.py
+++ b/tests/test_trade_lot_creation.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+from sqlalchemy import create_engine, select
+from zoneinfo import ZoneInfo
+
+from portfolio_tool.config import Config
+from portfolio_tool.core.trades import TradeInput, record_trade
+from portfolio_tool.data import models
+from portfolio_tool.data.repo import Database
+
+
+def test_buy_creates_lot_immediately() -> None:
+    engine = create_engine("sqlite+pysqlite:///:memory:")
+    models.Base.metadata.create_all(engine)
+    db = Database(engine)
+    cfg = Config()
+
+    trade_input = TradeInput(
+        side="BUY",
+        symbol="XYZ",
+        dt=dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc),
+        qty=Decimal("100"),
+        price=Decimal("10"),
+        fees=Decimal("5"),
+        exchange="ASX",
+        note="Test",
+    )
+
+    with db.session_scope() as session:
+        record_trade(session, cfg, trade_input)
+
+    with db.session_scope() as session:
+        lots = list(session.scalars(select(models.Lot)))
+        assert len(lots) == 1
+        lot = lots[0]
+        assert lot.qty_remaining == trade_input.qty
+        expected_cost_base = trade_input.qty * trade_input.price + trade_input.fees
+        assert lot.cost_base_total == expected_cost_base
+        tz = ZoneInfo(cfg.timezone)
+        expected_threshold = trade_input.dt.astimezone(tz).date() + dt.timedelta(days=365)
+        assert lot.threshold_date == expected_threshold

--- a/ui/events.py
+++ b/ui/events.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+try:  # pragma: no cover - textual optional dependency
+    from textual.message import Message
+except ModuleNotFoundError:  # pragma: no cover - fallback for tests without textual
+    class Message:  # type: ignore
+        """Stub Message base so tests without Textual can import events."""
+
+        pass
+
+
+class DataChanged(Message):
+    """Posted when data was added/edited/deleted and views must refresh."""
+
+    pass

--- a/ui/theme.tcss
+++ b/ui/theme.tcss
@@ -12,6 +12,35 @@ Screen {
     width: 24;
     background: #161821;
     padding: 1;
+    height: 100%;
+}
+
+#sidebar-title {
+    text-style: bold;
+    margin-bottom: 1;
+}
+
+#sidebar-nav {
+    height: auto;
+    gap: 1;
+    margin-bottom: 1;
+}
+
+.sidebar-button {
+    width: 100%;
+    border: tall transparent;
+}
+
+.sidebar-button.active {
+    background: #1f6feb;
+    color: #ffffff;
+    border: tall #1f6feb;
+    text-style: bold;
+}
+
+#sidebar-shortcuts {
+    color: #9aa5ce;
+    white-space: pre-line;
 }
 
 #main-content {

--- a/ui/widgets/sidebar.py
+++ b/ui/widgets/sidebar.py
@@ -1,34 +1,38 @@
 from __future__ import annotations
 
-from rich.panel import Panel
-from rich.table import Table
-from textual.widget import Widget
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.reactive import reactive
+from textual.widgets import Button, Static
 
 
-class Sidebar(Widget):
+class Sidebar(Static):
+    """Interactive navigation sidebar with keyboard hints."""
+
+    active: reactive[str] = reactive("dashboard")
+
     def __init__(self) -> None:
         super().__init__(id="sidebar")
-        self._active = "dashboard"
+
+    def compose(self) -> ComposeResult:
+        yield Static("Navigation", id="sidebar-title")
+        yield Vertical(
+            Button("1 Dashboard", id="nav-dashboard", classes="sidebar-button"),
+            Button("2 Positions", id="nav-positions", classes="sidebar-button"),
+            Button("3 Lots", id="nav-lots", classes="sidebar-button"),
+            Button("4 CGT Calendar", id="nav-cgt", classes="sidebar-button"),
+            Button("5 Actionables", id="nav-actionables", classes="sidebar-button"),
+            id="sidebar-nav",
+        )
+        yield Static("T Add Trade\nR Refresh Prices\n? Help", id="sidebar-shortcuts")
+
+    def on_mount(self) -> None:
+        self.highlight(self.active)
+        self.watch_active(self.active)
 
     def highlight(self, key: str) -> None:
-        self._active = key
-        self.refresh()
+        self.active = key
 
-    def render(self) -> Panel:
-        table = Table.grid(padding=0)
-        table.add_column(justify="left")
-        nav_items = {
-            "dashboard": "1 Dashboard",
-            "positions": "2 Positions",
-            "lots": "3 Lots",
-            "cgt": "4 CGT Calendar",
-            "actionables": "5 Actionables",
-        }
-        for key, label in nav_items.items():
-            style = "bold cyan" if key == self._active else "white"
-            table.add_row(f"[{style}]{label}[/]")
-        table.add_row("")
-        table.add_row("T Add Trade")
-        table.add_row("R Refresh Prices")
-        table.add_row("? Help")
-        return Panel(table, title="Navigation", border_style="blue")
+    def watch_active(self, active: str) -> None:
+        for button in self.query(Button):
+            button.set_class(button.id == f"nav-{active}", "active")


### PR DESCRIPTION
## Summary
- add a global `DataChanged` message, toast on trade save, and refresh handlers across the TUI
- guarantee navigation via number keys and sidebar buttons mounts and refreshes each view while logging refresh failures
- create a helper to build buy lots immediately with a regression test and document new TUI troubleshooting steps

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db32c8a48c83228b175b19539b47d3