### PR TITLE
Fix unsupported properties in Textual theme stylesheet

### DIFF
--- a/ui/theme.tcss
+++ b/ui/theme.tcss
@@ -22,13 +22,13 @@ Screen {
 
 #sidebar-nav {
     height: auto;
-    gap: 1;
     margin-bottom: 1;
 }
 
 .sidebar-button {
     width: 100%;
     border: tall transparent;
+    margin-bottom: 1;
 }
 
 .sidebar-button.active {
@@ -40,7 +40,6 @@ Screen {
 
 #sidebar-shortcuts {
     color: #9aa5ce;
-    white-space: pre-line;
 }
 
 #main-content {


### PR DESCRIPTION
## Summary
- remove unsupported gap and white-space declarations from the Textual theme
- add button margin to keep sidebar spacing without using unsupported properties

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db48a2f6e083228637158342690a4b