### PR TITLE
Refresh dashboard immediately after saving a trade

### DIFF
--- a/ui/widgets/add_trade_modal.py
+++ b/ui/widgets/add_trade_modal.py
@@ -108,8 +108,13 @@ class AddTradeModal(ModalScreen[None]):
 
         if success:
             self.error.update("")
-            if self.app:
-                self.app.post_message(DataChanged())
-                if hasattr(self.app, "toast"):
-                    self.app.toast("Trade saved; refreshing…")
+            app = self.app
+            if app:
+                refresh_all = getattr(app, "refresh_all", None)
+                if callable(refresh_all):
+                    refresh_all()
+                else:
+                    app.post_message(DataChanged())
+                if hasattr(app, "toast"):
+                    app.toast("Trade saved; refreshing…")
             self.dismiss()


### PR DESCRIPTION
## Summary
- call the portfolio app's refresh_all hook when a trade is saved from the modal
- fall back to posting the DataChanged message if refresh_all is unavailable while keeping the toast notification

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db706e254883228cb0cef2998a20f3