### PR TITLE
Refine header pricing status indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ All application data (configuration, SQLite database, and markdown exports) live
 
 ## Quick Troubleshooting
 
-### If the UI is empty or shows Offline
+### If the UI is empty or shows Offline/Prices stale
 1) Run `portfolio status` — check DB path and row counts.
 2) If Trades>0 and Lots=0, re-save a BUY (lot should be created) or file a bug.
 3) Run `portfolio price-refresh CSL.AX` to seed a fresh price.
-4) Ensure `offline_mode=false` in `~/.portfolio_tool/config.toml`.
+4) Ensure `offline_mode=false` in `~/.portfolio_tool/config.toml` if the header shows `[O] Offline`.
+5) If the header shows `[P] Prices stale` or `[P] No cached prices`, try refreshing prices or checking your network connection.
 
 ### TUI Troubleshooting
 

--- a/tests/test_header_widget.py
+++ b/tests/test_header_widget.py
@@ -1,0 +1,26 @@
+from portfolio_tool.config import Config
+from ui.textual_app import PriceStatus
+from ui.widgets.header import HeaderWidget
+
+
+def render_text_for_reason(reason: str) -> str:
+    widget = HeaderWidget(Config())
+    widget.update_status(PriceStatus(asof=None, stale=reason != "ok", reason=reason))
+    return widget.render().plain
+
+
+def test_header_shows_offline_when_offline_mode() -> None:
+    text = render_text_for_reason("offline_mode")
+    assert "[O] Offline [offline_mode]" in text
+
+
+def test_header_shows_prices_stale_message() -> None:
+    text = render_text_for_reason("stale")
+    assert "[P] Prices stale" in text
+    assert "[O] Offline" not in text
+
+
+def test_header_shows_no_cached_prices_message() -> None:
+    text = render_text_for_reason("no_prices")
+    assert "[P] No cached prices" in text
+    assert "[O] Offline" not in text

--- a/ui/widgets/header.py
+++ b/ui/widgets/header.py
@@ -38,5 +38,15 @@ class HeaderWidget(Widget):
         else:
             parts.append("Prices: —")
         if self._status.reason != "ok":
-            parts.append(f"[O] Offline [{self._status.reason}]")
+            parts.append(self._format_status_message())
         return Text(" | ".join(parts), style="bold white")
+
+    def _format_status_message(self) -> str:
+        reason = self._status.reason
+        if reason == "offline_mode":
+            return "[O] Offline [offline_mode]"
+        if reason == "stale":
+            return "[P] Prices stale"
+        if reason == "no_prices":
+            return "[P] No cached prices"
+        return f"[P] Prices {reason}"


### PR DESCRIPTION
## Summary
- update the header widget to show tailored labels for offline mode, stale prices, and missing price cache
- add unit tests that cover the header status rendering for each price reason
- document the new header status labels in the troubleshooting section

## Testing
- pytest tests/test_header_widget.py

------
https://chatgpt.com/codex/tasks/task_e_68dc3829d51c8322bf7957879cdb176d