### PR TITLE
Clarify price connection status in header

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ All application data (configuration, SQLite database, and markdown exports) live
 3) Run `portfolio price-refresh CSL.AX` to seed a fresh price.
 4) Ensure `offline_mode=false` in `~/.portfolio_tool/config.toml` if the header shows `[O] Offline`.
 5) If the header shows `[P] Prices stale` or `[P] No cached prices`, try refreshing prices or checking your network connection.
+6) When the header reads `[P] Prices current ✓` you have a fresh connection to the pricing APIs.
 
 ### TUI Troubleshooting
 

--- a/tests/test_header_widget.py
+++ b/tests/test_header_widget.py
@@ -14,6 +14,12 @@ def test_header_shows_offline_when_offline_mode() -> None:
     assert "[O] Offline [offline_mode]" in text
 
 
+def test_header_shows_prices_current_message_when_ok() -> None:
+    text = render_text_for_reason("ok")
+    assert "[P] Prices current" in text
+    assert "[O] Offline" not in text
+
+
 def test_header_shows_prices_stale_message() -> None:
     text = render_text_for_reason("stale")
     assert "[P] Prices stale" in text

--- a/ui/widgets/header.py
+++ b/ui/widgets/header.py
@@ -37,8 +37,9 @@ class HeaderWidget(Widget):
             parts.append(f"Prices: {timestamp}")
         else:
             parts.append("Prices: —")
-        if self._status.reason != "ok":
-            parts.append(self._format_status_message())
+        status_message = self._format_status_message()
+        if status_message:
+            parts.append(status_message)
         return Text(" | ".join(parts), style="bold white")
 
     def _format_status_message(self) -> str:
@@ -49,4 +50,6 @@ class HeaderWidget(Widget):
             return "[P] Prices stale"
         if reason == "no_prices":
             return "[P] No cached prices"
+        if reason == "ok":
+            return "[P] Prices current ✓"
         return f"[P] Prices {reason}"


### PR DESCRIPTION
## Summary
- show a success message in the header when fresh prices are available so users can confirm API connectivity
- extend header widget tests to cover the new success state
- document the new header message in the troubleshooting guide

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dc3abb64888322a305e7da72ffa435