### PR TITLE
Add fallback Text implementation for header widget

### DIFF
--- a/ui/widgets/header.py
+++ b/ui/widgets/header.py
@@ -4,7 +4,22 @@ import datetime as dt
 
 from typing import TYPE_CHECKING
 
-from rich.text import Text
+try:
+    from rich.text import Text
+except ModuleNotFoundError:  # pragma: no cover - fallback for minimal test envs
+    class Text:  # type: ignore[override]
+        """Fallback ``Text`` implementation used when ``rich`` is unavailable."""
+
+        def __init__(self, text: str, style: str | None = None) -> None:
+            self._text = text
+            self.style = style
+
+        @property
+        def plain(self) -> str:
+            return self._text
+
+        def __str__(self) -> str:  # pragma: no cover - debugging helper
+            return self._text
 from textual.widget import Widget
 
 from portfolio_tool.config import Config


### PR DESCRIPTION
## Summary
- add a local fallback ``Text`` implementation for the header widget when ``rich`` is unavailable
- retain the existing render behaviour so header tests can run without optional dependencies

## Testing
- pytest tests/test_header_widget.py

------
https://chatgpt.com/codex/tasks/task_e_68dc7f2a49b48322b08373a34596a82c