### PR TITLE
Auto-dismiss toast notifications to avoid covering the footer

### DIFF
--- a/ui/widgets/toasts.py
+++ b/ui/widgets/toasts.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from rich.console import RenderableType
 from rich.panel import Panel
+from textual.timer import Timer
 from textual.widget import Widget
 
 
@@ -11,22 +12,39 @@ class ToastManager(Widget):
     def __init__(self) -> None:
         super().__init__(id="toasts")
         self._messages: list[RenderableType] = []
+        self._dismiss_timer: Timer | None = None
+
+    def _show(self, message: RenderableType) -> None:
+        """Display a toast message for a short period before clearing it.
+
+        The footer contains keyboard shortcuts (1–5) and can easily be
+        obscured by lingering toasts. To avoid covering important UI hints or
+        freshly added rows, automatically dismiss the latest toast after a
+        brief delay.
+        """
+
+        self._messages.append(message)
+        self.refresh()
+
+        if self._dismiss_timer is not None:
+            self._dismiss_timer.stop()
+        self._dismiss_timer = self.set_timer(3, self._clear)
+
+    def _clear(self) -> None:
+        self._messages.clear()
+        self.refresh()
 
     def success(self, message: Any) -> None:
-        self._messages.append(Panel(str(message), title="Success", border_style="green"))
-        self.refresh()
+        self._show(Panel(str(message), title="Success", border_style="green"))
 
     def info(self, message: Any) -> None:
-        self._messages.append(Panel(str(message), title="Info", border_style="blue"))
-        self.refresh()
+        self._show(Panel(str(message), title="Info", border_style="blue"))
 
     def warning(self, message: Any) -> None:
-        self._messages.append(Panel(str(message), title="Warning", border_style="yellow"))
-        self.refresh()
+        self._show(Panel(str(message), title="Warning", border_style="yellow"))
 
     def error(self, message: Any) -> None:
-        self._messages.append(Panel(str(message), title="Error", border_style="red"))
-        self.refresh()
+        self._show(Panel(str(message), title="Error", border_style="red"))
 
     def render(self) -> RenderableType:
         if not self._messages:


### PR DESCRIPTION
## Summary
- add automatic dismissal to toast notifications so they don't linger and cover footer shortcuts
- ensure any pending dismissal timer is cancelled before scheduling a new one

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dca955b5bc8322a45b0cc0a238306d