### PR TITLE
feat: add data repositories with migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,6 @@ dist/
 build/
 logs/
 
+/data/
+
 config.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## Unreleased
-- Project scaffolding in progress.
+- Added data layer repositories (SQLite + JSON) with initial migrations.
+- Demo seeding and deterministic synthetic dataset scripts.
 
 ## 0.0.1 - Initial scaffolding
 - Established package structure and CLI stub.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 This project aims to build an auditable, deterministic portfolio management tool focused on Australian tax rules.
 
-## Stage 0 Status
+## Stage 1 Status
 
-- Python package scaffold with Typer-based CLI stub.
-- Default configuration (`config.toml`) generated automatically on first run.
-- Demo seeding script placeholder.
+- Persistence layer implemented with interchangeable SQLite and JSON repositories.
+- Automatic schema migrations (001_init) provision the required tables and indexes.
+- Demo seeding script now provisions both backends with example trades and a cached price.
+- Deterministic synthetic dataset generator (`scripts/gen_synth_50k.py`) for performance testing.
 
 Run the CLI help to confirm installation:
 
@@ -18,3 +19,5 @@ portfolio --help
 
 - Create a virtual environment: `make venv`
 - Run tests: `make test`
+- Generate demo data: `python scripts/seed_demo.py`
+- Build synthetic datasets: `python scripts/gen_synth_50k.py`

--- a/portfolio_tool/data/__init__.py
+++ b/portfolio_tool/data/__init__.py
@@ -1,0 +1,12 @@
+"""Persistence layer exports."""
+
+from .repo_base import BaseRepository, RepositoryError
+from .repo_json import JSONRepository
+from .repo_sqlite import SQLiteRepository
+
+__all__ = [
+    "BaseRepository",
+    "RepositoryError",
+    "JSONRepository",
+    "SQLiteRepository",
+]

--- a/portfolio_tool/data/migrations/001_init.sql
+++ b/portfolio_tool/data/migrations/001_init.sql
@@ -1,0 +1,78 @@
+-- Initialize core tables for the portfolio repository.
+CREATE TABLE IF NOT EXISTS transactions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    dt TEXT NOT NULL,
+    type TEXT NOT NULL,
+    symbol TEXT NOT NULL,
+    qty REAL NOT NULL,
+    price REAL NOT NULL,
+    fees REAL DEFAULT 0,
+    broker_ref TEXT,
+    notes TEXT,
+    exchange TEXT,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_transactions_symbol_dt
+    ON transactions(symbol, dt);
+
+CREATE TABLE IF NOT EXISTS lots (
+    lot_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    symbol TEXT NOT NULL,
+    acquired_at TEXT NOT NULL,
+    qty_remaining REAL NOT NULL,
+    cost_base_total REAL NOT NULL,
+    threshold_date TEXT,
+    source_txn_id INTEGER,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_lots_symbol_acquired
+    ON lots(symbol, acquired_at);
+
+CREATE TABLE IF NOT EXISTS disposals (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    sell_txn_id INTEGER NOT NULL,
+    lot_id INTEGER NOT NULL,
+    qty REAL NOT NULL,
+    proceeds REAL NOT NULL,
+    cost_base_alloc REAL NOT NULL,
+    gain_loss REAL NOT NULL,
+    eligible_for_discount INTEGER DEFAULT 0,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_disposals_sell
+    ON disposals(sell_txn_id);
+
+CREATE INDEX IF NOT EXISTS idx_disposals_lot
+    ON disposals(lot_id);
+
+CREATE TABLE IF NOT EXISTS price_cache (
+    symbol TEXT PRIMARY KEY,
+    asof TEXT NOT NULL,
+    price REAL NOT NULL,
+    source TEXT NOT NULL,
+    fetched_at TEXT NOT NULL,
+    stale INTEGER DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS actionables (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    type TEXT NOT NULL,
+    symbol TEXT,
+    message TEXT NOT NULL,
+    status TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    snoozed_until TEXT,
+    context TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_actionables_status
+    ON actionables(status);
+
+CREATE INDEX IF NOT EXISTS idx_actionables_symbol
+    ON actionables(symbol);

--- a/portfolio_tool/data/repo_base.py
+++ b/portfolio_tool/data/repo_base.py
@@ -1,0 +1,150 @@
+"""Repository base abstractions for persistence backends."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping
+
+
+@dataclass(frozen=True)
+class Migration:
+    """Represents a database migration script."""
+
+    version: str
+    name: str
+    sql: str
+
+
+class RepositoryError(RuntimeError):
+    """Raised when the repository encounters an unrecoverable error."""
+
+
+class BaseRepository(ABC):
+    """Abstract repository API shared by all persistence backends."""
+
+    # --- lifecycle -----------------------------------------------------
+    def close(self) -> None:
+        """Close any underlying resources (optional)."""
+
+    # --- transactions --------------------------------------------------
+    @abstractmethod
+    def add_transaction(self, txn: Mapping[str, Any]) -> int:
+        """Insert a transaction and return its identifier."""
+
+    @abstractmethod
+    def get_transaction(self, txn_id: int) -> dict[str, Any] | None:
+        """Fetch a transaction by identifier."""
+
+    @abstractmethod
+    def list_transactions(
+        self,
+        *,
+        symbol: str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+        order: str = "asc",
+    ) -> list[dict[str, Any]]:
+        """List transactions optionally filtered by symbol."""
+
+    @abstractmethod
+    def update_transaction(self, txn_id: int, updates: Mapping[str, Any]) -> None:
+        """Apply updates to an existing transaction."""
+
+    @abstractmethod
+    def delete_transaction(self, txn_id: int) -> None:
+        """Remove a transaction by identifier."""
+
+    # --- lots ----------------------------------------------------------
+    @abstractmethod
+    def add_lot(self, lot: Mapping[str, Any]) -> int:
+        """Persist a cost base lot."""
+
+    @abstractmethod
+    def update_lot(self, lot_id: int, updates: Mapping[str, Any]) -> None:
+        """Update a stored lot."""
+
+    @abstractmethod
+    def list_lots(
+        self,
+        *,
+        symbol: str | None = None,
+        only_open: bool = False,
+    ) -> list[dict[str, Any]]:
+        """Return lots, optionally filtered by symbol or open quantity."""
+
+    @abstractmethod
+    def delete_lot(self, lot_id: int) -> None:
+        """Delete a lot (used for data resets/testing)."""
+
+    # --- disposals -----------------------------------------------------
+    @abstractmethod
+    def add_disposal(self, disposal: Mapping[str, Any]) -> int:
+        """Insert a disposal slice."""
+
+    @abstractmethod
+    def list_disposals(
+        self,
+        *,
+        sell_txn_id: int | None = None,
+        lot_id: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """List disposal slices filtered by sell transaction or lot."""
+
+    @abstractmethod
+    def delete_disposals_for_sell(self, sell_txn_id: int) -> None:
+        """Remove existing disposal links for a sell transaction."""
+
+    # --- price cache ---------------------------------------------------
+    @abstractmethod
+    def upsert_price(self, record: Mapping[str, Any]) -> None:
+        """Store or update a cached price quote."""
+
+    @abstractmethod
+    def get_prices(self, symbols: Iterable[str]) -> dict[str, dict[str, Any]]:
+        """Return cached price quotes for the requested symbols."""
+
+    @abstractmethod
+    def purge_price(self, symbol: str) -> None:
+        """Remove a cached price entry."""
+
+    # --- actionables ---------------------------------------------------
+    @abstractmethod
+    def add_actionable(self, actionable: Mapping[str, Any]) -> int:
+        """Persist a new actionable item."""
+
+    @abstractmethod
+    def update_actionable(self, actionable_id: int, updates: Mapping[str, Any]) -> None:
+        """Update fields on an actionable item."""
+
+    @abstractmethod
+    def list_actionables(
+        self,
+        *,
+        status: str | None = None,
+        include_snoozed: bool = True,
+    ) -> list[dict[str, Any]]:
+        """Retrieve actionable items optionally filtered by status."""
+
+    # --- utility -------------------------------------------------------
+    def __enter__(self) -> "BaseRepository":  # pragma: no cover - convenience
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:  # pragma: no cover - convenience
+        self.close()
+
+
+def normalise_order(order: str) -> str:
+    """Validate ordering inputs."""
+
+    order = (order or "asc").lower()
+    if order not in {"asc", "desc"}:
+        raise RepositoryError(f"Unsupported order: {order!r}")
+    return order
+
+
+__all__ = [
+    "BaseRepository",
+    "RepositoryError",
+    "Migration",
+    "normalise_order",
+]

--- a/portfolio_tool/data/repo_json.py
+++ b/portfolio_tool/data/repo_json.py
@@ -1,0 +1,224 @@
+"""Portable JSON-backed repository implementation."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from .repo_base import BaseRepository, RepositoryError, normalise_order
+
+_DEFAULT_STATE = {
+    "meta": {
+        "next_ids": {
+            "transactions": 1,
+            "lots": 1,
+            "disposals": 1,
+            "actionables": 1,
+        }
+    },
+    "transactions": [],
+    "lots": [],
+    "disposals": [],
+    "price_cache": {},
+    "actionables": [],
+}
+
+
+class JSONRepository(BaseRepository):
+    """Repository that persists state in a JSON document."""
+
+    def __init__(self, path: Path | str) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        if not self.path.exists():
+            self._write_state(_DEFAULT_STATE)
+        self._state = self._read_state()
+
+    # ------------------------------------------------------------------
+    def close(self) -> None:
+        self._write_state(self._state)
+
+    # ------------------------------------------------------------------
+    def _read_state(self) -> dict[str, Any]:
+        try:
+            with self.path.open("r", encoding="utf-8") as fh:
+                return json.load(fh)
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+            raise RepositoryError(f"Invalid JSON repository: {exc}") from exc
+
+    def _write_state(self, state: Mapping[str, Any]) -> None:
+        with self.path.open("w", encoding="utf-8") as fh:
+            json.dump(state, fh, indent=2, sort_keys=True)
+
+    def _next_id(self, key: str) -> int:
+        counter = self._state["meta"]["next_ids"]
+        value = counter[key]
+        counter[key] = value + 1
+        return value
+
+    def _persist(self) -> None:
+        self._write_state(self._state)
+
+    # --- transactions --------------------------------------------------
+    def add_transaction(self, txn: Mapping[str, Any]) -> int:
+        txn_id = self._next_id("transactions")
+        record = {"id": txn_id, **txn}
+        self._state["transactions"].append(record)
+        self._persist()
+        return txn_id
+
+    def get_transaction(self, txn_id: int) -> dict[str, Any] | None:
+        for row in self._state["transactions"]:
+            if row["id"] == txn_id:
+                return row.copy()
+        return None
+
+    def list_transactions(
+        self,
+        *,
+        symbol: str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+        order: str = "asc",
+    ) -> list[dict[str, Any]]:
+        order = normalise_order(order)
+        rows = [row.copy() for row in self._state["transactions"]]
+        if symbol:
+            rows = [row for row in rows if row["symbol"] == symbol]
+        rows.sort(key=lambda r: (r["dt"], r["id"]), reverse=order == "desc")
+        if limit is not None:
+            rows = rows[offset : offset + limit]
+        return rows
+
+    def update_transaction(self, txn_id: int, updates: Mapping[str, Any]) -> None:
+        for row in self._state["transactions"]:
+            if row["id"] == txn_id:
+                row.update(updates)
+                self._persist()
+                return
+        raise RepositoryError(f"Transaction {txn_id} not found")
+
+    def delete_transaction(self, txn_id: int) -> None:
+        rows = self._state["transactions"]
+        for idx, row in enumerate(rows):
+            if row["id"] == txn_id:
+                rows.pop(idx)
+                self._persist()
+                return
+
+    # --- lots ----------------------------------------------------------
+    def add_lot(self, lot: Mapping[str, Any]) -> int:
+        lot_id = self._next_id("lots")
+        record = {"lot_id": lot_id, **lot}
+        self._state["lots"].append(record)
+        self._persist()
+        return lot_id
+
+    def update_lot(self, lot_id: int, updates: Mapping[str, Any]) -> None:
+        for row in self._state["lots"]:
+            if row["lot_id"] == lot_id:
+                row.update(updates)
+                self._persist()
+                return
+        raise RepositoryError(f"Lot {lot_id} not found")
+
+    def list_lots(
+        self,
+        *,
+        symbol: str | None = None,
+        only_open: bool = False,
+    ) -> list[dict[str, Any]]:
+        rows = [row.copy() for row in self._state["lots"]]
+        if symbol:
+            rows = [row for row in rows if row["symbol"] == symbol]
+        if only_open:
+            rows = [row for row in rows if row.get("qty_remaining", 0) > 0]
+        rows.sort(key=lambda r: (r.get("acquired_at"), r["lot_id"]))
+        return rows
+
+    def delete_lot(self, lot_id: int) -> None:
+        rows = self._state["lots"]
+        for idx, row in enumerate(rows):
+            if row["lot_id"] == lot_id:
+                rows.pop(idx)
+                self._persist()
+                return
+
+    # --- disposals -----------------------------------------------------
+    def add_disposal(self, disposal: Mapping[str, Any]) -> int:
+        disp_id = self._next_id("disposals")
+        record = {"id": disp_id, **disposal}
+        self._state["disposals"].append(record)
+        self._persist()
+        return disp_id
+
+    def list_disposals(
+        self,
+        *,
+        sell_txn_id: int | None = None,
+        lot_id: int | None = None,
+    ) -> list[dict[str, Any]]:
+        rows = [row.copy() for row in self._state["disposals"]]
+        if sell_txn_id is not None:
+            rows = [row for row in rows if row.get("sell_txn_id") == sell_txn_id]
+        if lot_id is not None:
+            rows = [row for row in rows if row.get("lot_id") == lot_id]
+        rows.sort(key=lambda r: r["id"])
+        return rows
+
+    def delete_disposals_for_sell(self, sell_txn_id: int) -> None:
+        rows = self._state["disposals"]
+        self._state["disposals"] = [
+            row for row in rows if row.get("sell_txn_id") != sell_txn_id
+        ]
+        self._persist()
+
+    # --- price cache ---------------------------------------------------
+    def upsert_price(self, record: Mapping[str, Any]) -> None:
+        symbol = record["symbol"]
+        self._state["price_cache"][symbol] = dict(record)
+        self._persist()
+
+    def get_prices(self, symbols: Iterable[str]) -> dict[str, dict[str, Any]]:
+        return {
+            symbol: self._state["price_cache"][symbol].copy()
+            for symbol in symbols
+            if symbol in self._state["price_cache"]
+        }
+
+    def purge_price(self, symbol: str) -> None:
+        self._state["price_cache"].pop(symbol, None)
+        self._persist()
+
+    # --- actionables ---------------------------------------------------
+    def add_actionable(self, actionable: Mapping[str, Any]) -> int:
+        actionable_id = self._next_id("actionables")
+        record = {"id": actionable_id, **actionable}
+        self._state["actionables"].append(record)
+        self._persist()
+        return actionable_id
+
+    def update_actionable(self, actionable_id: int, updates: Mapping[str, Any]) -> None:
+        for row in self._state["actionables"]:
+            if row["id"] == actionable_id:
+                row.update(updates)
+                self._persist()
+                return
+        raise RepositoryError(f"Actionable {actionable_id} not found")
+
+    def list_actionables(
+        self,
+        *,
+        status: str | None = None,
+        include_snoozed: bool = True,
+    ) -> list[dict[str, Any]]:
+        rows = [row.copy() for row in self._state["actionables"]]
+        if status:
+            rows = [row for row in rows if row.get("status") == status]
+        if not include_snoozed:
+            rows = [row for row in rows if row.get("snoozed_until") in (None, "")]
+        rows.sort(key=lambda r: r["created_at"])
+        return rows
+
+
+__all__ = ["JSONRepository"]

--- a/portfolio_tool/data/repo_sqlite.py
+++ b/portfolio_tool/data/repo_sqlite.py
@@ -1,0 +1,245 @@
+"""SQLite-backed repository implementation."""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from .repo_base import BaseRepository, RepositoryError, normalise_order
+
+MIGRATIONS_DIR = Path(__file__).with_suffix("").parent / "migrations"
+
+
+class SQLiteRepository(BaseRepository):
+    """Repository backed by a SQLite database file."""
+
+    def __init__(self, path: Path | str) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(self.path)
+        self._conn.row_factory = sqlite3.Row
+        self._apply_migrations()
+
+    # ------------------------------------------------------------------
+    def close(self) -> None:
+        if getattr(self, "_conn", None) is not None:
+            self._conn.close()
+
+    # ------------------------------------------------------------------
+    def _apply_migrations(self) -> None:
+        conn = self._conn
+        conn.execute("PRAGMA foreign_keys = ON;")
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS schema_migrations (version TEXT PRIMARY KEY);"
+        )
+        applied = {
+            row["version"]
+            for row in conn.execute("SELECT version FROM schema_migrations;")
+        }
+        for path in sorted(MIGRATIONS_DIR.glob("*.sql")):
+            version = path.stem.split("_")[0]
+            if version in applied:
+                continue
+            sql = path.read_text()
+            conn.executescript(sql)
+            conn.execute(
+                "INSERT INTO schema_migrations(version) VALUES (?);", (version,)
+            )
+        conn.commit()
+
+    # ------------------------------------------------------------------
+    def _execute(self, query: str, params: tuple[Any, ...] = ()) -> sqlite3.Cursor:
+        try:
+            cur = self._conn.execute(query, params)
+            self._conn.commit()
+            return cur
+        except sqlite3.DatabaseError as exc:  # pragma: no cover - defensive
+            raise RepositoryError(str(exc)) from exc
+
+    def _fetchall(self, query: str, params: tuple[Any, ...] = ()) -> list[dict[str, Any]]:
+        cur = self._execute(query, params)
+        return [dict(row) for row in cur.fetchall()]
+
+    # --- transactions --------------------------------------------------
+    def add_transaction(self, txn: Mapping[str, Any]) -> int:
+        columns = ", ".join(txn.keys())
+        placeholders = ", ".join(["?"] * len(txn))
+        cur = self._execute(
+            f"INSERT INTO transactions ({columns}) VALUES ({placeholders});",
+            tuple(txn.values()),
+        )
+        return int(cur.lastrowid)
+
+    def get_transaction(self, txn_id: int) -> dict[str, Any] | None:
+        cur = self._execute(
+            "SELECT * FROM transactions WHERE id = ?;", (txn_id,)
+        )
+        row = cur.fetchone()
+        return dict(row) if row else None
+
+    def list_transactions(
+        self,
+        *,
+        symbol: str | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+        order: str = "asc",
+    ) -> list[dict[str, Any]]:
+        order = normalise_order(order)
+        query = "SELECT * FROM transactions"
+        params: list[Any] = []
+        if symbol:
+            query += " WHERE symbol = ?"
+            params.append(symbol)
+        query += f" ORDER BY dt {order.upper()}"
+        if limit is not None:
+            query += " LIMIT ? OFFSET ?"
+            params.extend([limit, offset])
+        return self._fetchall(query + ";", tuple(params))
+
+    def update_transaction(self, txn_id: int, updates: Mapping[str, Any]) -> None:
+        assignments = ", ".join(f"{k} = ?" for k in updates)
+        params = list(updates.values()) + [txn_id]
+        self._execute(
+            f"UPDATE transactions SET {assignments} WHERE id = ?;", tuple(params)
+        )
+
+    def delete_transaction(self, txn_id: int) -> None:
+        self._execute("DELETE FROM transactions WHERE id = ?;", (txn_id,))
+
+    # --- lots ----------------------------------------------------------
+    def add_lot(self, lot: Mapping[str, Any]) -> int:
+        columns = ", ".join(lot.keys())
+        placeholders = ", ".join(["?"] * len(lot))
+        cur = self._execute(
+            f"INSERT INTO lots ({columns}) VALUES ({placeholders});",
+            tuple(lot.values()),
+        )
+        return int(cur.lastrowid)
+
+    def update_lot(self, lot_id: int, updates: Mapping[str, Any]) -> None:
+        assignments = ", ".join(f"{k} = ?" for k in updates)
+        params = list(updates.values()) + [lot_id]
+        self._execute(f"UPDATE lots SET {assignments} WHERE lot_id = ?;", tuple(params))
+
+    def list_lots(
+        self,
+        *,
+        symbol: str | None = None,
+        only_open: bool = False,
+    ) -> list[dict[str, Any]]:
+        query = "SELECT * FROM lots"
+        clauses: list[str] = []
+        params: list[Any] = []
+        if symbol:
+            clauses.append("symbol = ?")
+            params.append(symbol)
+        if only_open:
+            clauses.append("qty_remaining > 0")
+        if clauses:
+            query += " WHERE " + " AND ".join(clauses)
+        query += " ORDER BY acquired_at ASC, lot_id ASC;"
+        return self._fetchall(query, tuple(params))
+
+    def delete_lot(self, lot_id: int) -> None:
+        self._execute("DELETE FROM lots WHERE lot_id = ?;", (lot_id,))
+
+    # --- disposals -----------------------------------------------------
+    def add_disposal(self, disposal: Mapping[str, Any]) -> int:
+        columns = ", ".join(disposal.keys())
+        placeholders = ", ".join(["?"] * len(disposal))
+        cur = self._execute(
+            f"INSERT INTO disposals ({columns}) VALUES ({placeholders});",
+            tuple(disposal.values()),
+        )
+        return int(cur.lastrowid)
+
+    def list_disposals(
+        self,
+        *,
+        sell_txn_id: int | None = None,
+        lot_id: int | None = None,
+    ) -> list[dict[str, Any]]:
+        query = "SELECT * FROM disposals"
+        clauses: list[str] = []
+        params: list[Any] = []
+        if sell_txn_id is not None:
+            clauses.append("sell_txn_id = ?")
+            params.append(sell_txn_id)
+        if lot_id is not None:
+            clauses.append("lot_id = ?")
+            params.append(lot_id)
+        if clauses:
+            query += " WHERE " + " AND ".join(clauses)
+        query += " ORDER BY id ASC;"
+        return self._fetchall(query, tuple(params))
+
+    def delete_disposals_for_sell(self, sell_txn_id: int) -> None:
+        self._execute("DELETE FROM disposals WHERE sell_txn_id = ?;", (sell_txn_id,))
+
+    # --- price cache ---------------------------------------------------
+    def upsert_price(self, record: Mapping[str, Any]) -> None:
+        columns = list(record.keys())
+        placeholders = ", ".join(["?"] * len(columns))
+        assignments = ", ".join(f"{col} = excluded.{col}" for col in columns if col != "symbol")
+        self._execute(
+            f"""
+            INSERT INTO price_cache ({', '.join(columns)})
+            VALUES ({placeholders})
+            ON CONFLICT(symbol) DO UPDATE SET {assignments};
+            """,
+            tuple(record[col] for col in columns),
+        )
+
+    def get_prices(self, symbols: Iterable[str]) -> dict[str, dict[str, Any]]:
+        sym_list = list(symbols)
+        if not sym_list:
+            return {}
+        placeholders = ", ".join(["?"] * len(sym_list))
+        rows = self._fetchall(
+            f"SELECT * FROM price_cache WHERE symbol IN ({placeholders});",
+            tuple(sym_list),
+        )
+        return {row["symbol"]: row for row in rows}
+
+    def purge_price(self, symbol: str) -> None:
+        self._execute("DELETE FROM price_cache WHERE symbol = ?;", (symbol,))
+
+    # --- actionables ---------------------------------------------------
+    def add_actionable(self, actionable: Mapping[str, Any]) -> int:
+        columns = ", ".join(actionable.keys())
+        placeholders = ", ".join(["?"] * len(actionable))
+        cur = self._execute(
+            f"INSERT INTO actionables ({columns}) VALUES ({placeholders});",
+            tuple(actionable.values()),
+        )
+        return int(cur.lastrowid)
+
+    def update_actionable(self, actionable_id: int, updates: Mapping[str, Any]) -> None:
+        assignments = ", ".join(f"{k} = ?" for k in updates)
+        params = list(updates.values()) + [actionable_id]
+        self._execute(
+            f"UPDATE actionables SET {assignments} WHERE id = ?;", tuple(params)
+        )
+
+    def list_actionables(
+        self,
+        *,
+        status: str | None = None,
+        include_snoozed: bool = True,
+    ) -> list[dict[str, Any]]:
+        query = "SELECT * FROM actionables"
+        clauses: list[str] = []
+        params: list[Any] = []
+        if status:
+            clauses.append("status = ?")
+            params.append(status)
+        if not include_snoozed:
+            clauses.append("snoozed_until IS NULL")
+        if clauses:
+            query += " WHERE " + " AND ".join(clauses)
+        query += " ORDER BY created_at ASC;"
+        return self._fetchall(query, tuple(params))
+
+
+__all__ = ["SQLiteRepository"]

--- a/portfolio_tool/tests/test_repositories.py
+++ b/portfolio_tool/tests/test_repositories.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+
+import pytest
+from zoneinfo import ZoneInfo
+
+from portfolio_tool.data import JSONRepository, SQLiteRepository
+
+_TZ = ZoneInfo("Australia/Brisbane")
+
+
+@pytest.fixture(params=["sqlite", "json"])
+def repo(tmp_path, request):
+    if request.param == "sqlite":
+        instance = SQLiteRepository(tmp_path / "test.sqlite")
+    else:
+        instance = JSONRepository(tmp_path / "test.json")
+    yield instance
+    instance.close()
+
+
+def _sample_txn(symbol: str = "CSL") -> dict:
+    return {
+        "dt": datetime(2024, 1, 2, 10, 0, tzinfo=_TZ).isoformat(),
+        "type": "BUY",
+        "symbol": symbol,
+        "qty": 10.0,
+        "price": 240.5,
+        "fees": 9.95,
+        "broker_ref": "TEST-1",
+        "notes": "unit test",
+        "exchange": "ASX",
+    }
+
+
+def _sample_lot(symbol: str = "CSL") -> dict:
+    return {
+        "symbol": symbol,
+        "acquired_at": datetime(2024, 1, 2, 10, 0, tzinfo=_TZ).isoformat(),
+        "qty_remaining": 10.0,
+        "cost_base_total": 2405.0,
+        "threshold_date": datetime(2025, 1, 2, 10, 0, tzinfo=_TZ).isoformat(),
+        "source_txn_id": 1,
+    }
+
+
+def _sample_disposal(lot_id: int, sell_txn_id: int = 2) -> dict:
+    return {
+        "sell_txn_id": sell_txn_id,
+        "lot_id": lot_id,
+        "qty": 5.0,
+        "proceeds": 1300.0,
+        "cost_base_alloc": 1200.0,
+        "gain_loss": 100.0,
+        "eligible_for_discount": 1,
+    }
+
+
+def _sample_price(symbol: str = "CSL") -> dict:
+    now = datetime(2024, 3, 1, 12, 0, tzinfo=_TZ)
+    return {
+        "symbol": symbol,
+        "asof": now.isoformat(),
+        "price": 250.25,
+        "source": "unit-test",
+        "fetched_at": now.isoformat(),
+        "stale": 0,
+    }
+
+
+def _sample_actionable(symbol: str = "CSL") -> dict:
+    created = datetime(2024, 2, 15, 9, 0, tzinfo=_TZ).isoformat()
+    return {
+        "type": "RULE",
+        "symbol": symbol,
+        "message": "Check position sizing",
+        "status": "OPEN",
+        "created_at": created,
+        "updated_at": created,
+        "snoozed_until": None,
+        "context": "{}",
+    }
+
+
+def test_transaction_crud(repo):
+    txn_id = repo.add_transaction(_sample_txn())
+    fetched = repo.get_transaction(txn_id)
+    assert fetched["symbol"] == "CSL"
+    repo.update_transaction(txn_id, {"notes": "updated"})
+    updated = repo.get_transaction(txn_id)
+    assert updated["notes"] == "updated"
+    repo.delete_transaction(txn_id)
+    assert repo.get_transaction(txn_id) is None
+
+
+def test_list_transactions_order(repo):
+    repo.add_transaction(_sample_txn("CSL"))
+    second = _sample_txn("BHP")
+    second["dt"] = datetime(2024, 1, 3, 10, 0, tzinfo=_TZ).isoformat()
+    repo.add_transaction(second)
+    rows = repo.list_transactions(order="desc")
+    assert rows[0]["symbol"] == "BHP"
+    rows_symbol = repo.list_transactions(symbol="CSL")
+    assert all(row["symbol"] == "CSL" for row in rows_symbol)
+
+
+def test_lot_and_disposal_roundtrip(repo):
+    lot_id = repo.add_lot(_sample_lot())
+    repo.update_lot(lot_id, {"qty_remaining": 4.0})
+    lots = repo.list_lots()
+    assert lots[0]["qty_remaining"] == 4.0
+    open_lots = repo.list_lots(only_open=True)
+    assert open_lots
+    repo.update_lot(lot_id, {"qty_remaining": 0.0})
+    assert repo.list_lots(only_open=True) == []
+
+    disposal_id = repo.add_disposal(_sample_disposal(lot_id))
+    disposals = repo.list_disposals(lot_id=lot_id)
+    assert disposals[0]["id"] == disposal_id
+    repo.delete_disposals_for_sell(_sample_disposal(lot_id)["sell_txn_id"])
+    assert repo.list_disposals(lot_id=lot_id) == []
+
+
+def test_price_cache_roundtrip(repo):
+    record = _sample_price()
+    repo.upsert_price(record)
+    prices = repo.get_prices(["CSL"])
+    assert prices["CSL"]["price"] == 250.25
+    updated = record | {"price": 260.0, "stale": 1}
+    repo.upsert_price(updated)
+    prices = repo.get_prices(["CSL"])
+    assert prices["CSL"]["price"] == 260.0
+    repo.purge_price("CSL")
+    assert repo.get_prices(["CSL"]) == {}
+
+
+def test_actionables_roundtrip(repo):
+    actionable_id = repo.add_actionable(_sample_actionable())
+    rows = repo.list_actionables()
+    assert rows[0]["id"] == actionable_id
+    repo.update_actionable(actionable_id, {"status": "DONE", "updated_at": datetime.now(tz=_TZ).isoformat()})
+    done = repo.list_actionables(status="DONE")
+    assert len(done) == 1
+    repo.update_actionable(actionable_id, {"snoozed_until": datetime(2024, 3, 1, tzinfo=_TZ).isoformat()})
+    active = repo.list_actionables(include_snoozed=False)
+    assert active == []
+
+
+def test_sqlite_migration_runs(tmp_path):
+    db_path = tmp_path / "migrated.sqlite"
+    repo = SQLiteRepository(db_path)
+    try:
+        repo.add_transaction(_sample_txn())
+    finally:
+        repo.close()
+    with sqlite3.connect(db_path) as conn:
+        cur = conn.execute("SELECT version FROM schema_migrations")
+        versions = {row[0] for row in cur.fetchall()}
+    assert "001" in versions
+
+
+def _summarise(repo):
+    txns = repo.list_transactions()
+    lots = repo.list_lots()
+    disposals = repo.list_disposals()
+    prices = repo.get_prices(["CSL"])
+    actionables = repo.list_actionables()
+    return {
+        "transactions": [
+            {k: row[k] for k in ("type", "symbol", "qty", "price", "fees")}
+            for row in txns
+        ],
+        "lots": [
+            {k: row[k] for k in ("symbol", "qty_remaining", "cost_base_total")}
+            for row in lots
+        ],
+        "disposals": [
+            {k: row[k] for k in ("sell_txn_id", "lot_id", "qty", "gain_loss")}
+            for row in disposals
+        ],
+        "prices": {symbol: {"price": rec["price"]} for symbol, rec in prices.items()},
+        "actionables": [
+            {k: row[k] for k in ("type", "status", "symbol")}
+            for row in actionables
+        ],
+    }
+
+
+def test_repositories_parity(tmp_path):
+    sqlite_repo = SQLiteRepository(tmp_path / "parity.sqlite")
+    json_repo = JSONRepository(tmp_path / "parity.json")
+
+    for repo in (sqlite_repo, json_repo):
+        txn_id = repo.add_transaction(_sample_txn())
+        lot_id = repo.add_lot(_sample_lot())
+        repo.add_disposal(_sample_disposal(lot_id, sell_txn_id=txn_id))
+        repo.upsert_price(_sample_price())
+        repo.add_actionable(_sample_actionable())
+
+    sqlite_state = _summarise(sqlite_repo)
+    json_state = _summarise(json_repo)
+
+    sqlite_repo.close()
+    json_repo.close()
+
+    assert sqlite_state == json_state

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.11"
 dependencies = [
     "typer[all]>=0.9",
     "tomli-w>=1.0.0",
+    "tzdata>=2023.3",
 ]
 
 [project.optional-dependencies]

--- a/scripts/gen_synth_50k.py
+++ b/scripts/gen_synth_50k.py
@@ -1,0 +1,92 @@
+"""Generate deterministic synthetic datasets for performance testing."""
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timedelta
+from pathlib import Path
+from random import Random
+from zoneinfo import ZoneInfo
+
+from portfolio_tool.data import JSONRepository, SQLiteRepository
+
+_TZ = ZoneInfo("Australia/Brisbane")
+_SYMBOLS = ["CSL", "BHP", "IOZ", "VAS", "APT", "WES", "TLS", "CBA"]
+_BASE_PRICES = {
+    "CSL": 240.0,
+    "BHP": 42.5,
+    "IOZ": 32.0,
+    "VAS": 90.0,
+    "APT": 75.0,
+    "WES": 48.0,
+    "TLS": 4.2,
+    "CBA": 100.0,
+}
+
+
+def _synth_transactions(count: int, seed: int = 2024):
+    rng = Random(seed)
+    start = datetime(2012, 1, 3, 10, 0, tzinfo=_TZ)
+    for idx in range(count):
+        symbol = _SYMBOLS[idx % len(_SYMBOLS)]
+        side_toggle = idx % 5
+        txn_type = "BUY" if side_toggle < 3 else "SELL"
+        qty = float((rng.randint(1, 25) * 5) if txn_type == "BUY" else (rng.randint(1, 10) * 5))
+        base = _BASE_PRICES[symbol]
+        price_variation = 1 + rng.uniform(-0.12, 0.12)
+        price = round(base * price_variation, 4)
+        dt = start + timedelta(days=idx // len(_SYMBOLS), minutes=idx % 360)
+        yield {
+            "dt": dt.isoformat(),
+            "type": txn_type,
+            "symbol": symbol,
+            "qty": qty,
+            "price": price,
+            "fees": round(4.5 + qty * 0.015, 2),
+            "broker_ref": f"SYN-{idx:05d}",
+            "notes": f"Synthetic trade #{idx}",
+            "exchange": "ASX",
+        }
+
+
+def _seed_repo(repo, txns) -> None:
+    for txn in txns:
+        repo.add_transaction(txn)
+    repo.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dir", type=Path, default=Path("data"), help="Output directory")
+    parser.add_argument("--count", type=int, default=50_000, help="Number of trades to generate")
+    parser.add_argument(
+        "--backends",
+        nargs="+",
+        choices=["sqlite", "json"],
+        default=["sqlite", "json"],
+        help="Backends to generate",
+    )
+    args = parser.parse_args()
+
+    args.dir.mkdir(parents=True, exist_ok=True)
+
+    txns = list(_synth_transactions(args.count))
+
+    if "sqlite" in args.backends:
+        sqlite_path = args.dir / "synth.sqlite"
+        if sqlite_path.exists():
+            sqlite_path.unlink()
+        sqlite_repo = SQLiteRepository(sqlite_path)
+        _seed_repo(sqlite_repo, txns)
+        print(f"Generated SQLite dataset: {sqlite_path} ({args.count} txns)")
+
+    if "json" in args.backends:
+        json_path = args.dir / "synth.json"
+        if json_path.exists():
+            json_path.unlink()
+        json_repo = JSONRepository(json_path)
+        _seed_repo(json_repo, txns)
+        print(f"Generated JSON dataset: {json_path} ({args.count} txns)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/seed_demo.py
+++ b/scripts/seed_demo.py
@@ -1,19 +1,73 @@
 """Seed a demo dataset for the portfolio tool."""
 from __future__ import annotations
 
+from datetime import datetime
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 from portfolio_tool.app.cli import ensure_config
+from portfolio_tool.data import JSONRepository, SQLiteRepository
+
+_TZ = ZoneInfo("Australia/Brisbane")
+
+_SAMPLE_TRANSACTIONS = [
+    {
+        "dt": datetime(2024, 1, 2, 10, 0, tzinfo=_TZ).isoformat(),
+        "type": "BUY",
+        "symbol": "CSL",
+        "qty": 10.0,
+        "price": 240.0,
+        "fees": 9.95,
+        "broker_ref": "DEMO-1",
+        "notes": "Initial CSL position",
+        "exchange": "ASX",
+    },
+    {
+        "dt": datetime(2024, 3, 15, 11, 0, tzinfo=_TZ).isoformat(),
+        "type": "BUY",
+        "symbol": "IOZ",
+        "qty": 50.0,
+        "price": 32.5,
+        "fees": 9.95,
+        "broker_ref": "DEMO-2",
+        "notes": "ETF accumulation",
+        "exchange": "ASX",
+    },
+]
+
+_SAMPLE_PRICE = {
+    "symbol": "CSL",
+    "asof": datetime(2024, 3, 15, 16, 0, tzinfo=_TZ).isoformat(),
+    "price": 245.75,
+    "source": "manual_seed",
+    "fetched_at": datetime.now(tz=_TZ).isoformat(),
+    "stale": 0,
+}
+
+
+def _seed_repo(repo) -> None:
+    if repo.list_transactions():
+        return
+    for txn in _SAMPLE_TRANSACTIONS:
+        repo.add_transaction(txn)
+    repo.upsert_price(_SAMPLE_PRICE)
+    repo.close()
 
 
 def main() -> None:
     config_path = ensure_config()
-    demo_dir = Path("data")
-    demo_dir.mkdir(exist_ok=True)
-    demo_file = demo_dir / "demo.txt"
-    demo_file.write_text("Demo dataset placeholder. Configure repositories in later stages.\n")
+    data_dir = Path("data")
+    data_dir.mkdir(exist_ok=True)
+
+    sqlite_repo = SQLiteRepository(data_dir / "demo.sqlite")
+    json_repo = JSONRepository(data_dir / "demo.json")
+
+    _seed_repo(sqlite_repo)
+    _seed_repo(json_repo)
+
     print(f"Config ensured at {config_path}")
-    print(f"Demo data placeholder written to {demo_file}")
+    print(f"Seeded demo SQLite database at {sqlite_repo.path}")
+    print(f"Seeded demo JSON store at {json_repo.path}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add SQLite and JSON repository backends with shared base API and schema migration
- update demo seeding and introduce deterministic synthetic dataset script
- cover repository CRUD behaviour and backend parity with new pytest suite

## Testing
- python scripts/seed_demo.py
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ddeaf8027483228dfd5e4bd53fa185