### PR TITLE
feat(pricing): add live pricing subsystem and CLI commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Core domain services covering lot matching (FIFO/HIFO/Specific-ID), CGT disposal slicing, and brokerage allocation utilities.
 - Added data layer repositories (SQLite + JSON) with initial migrations.
 - Demo seeding and deterministic synthetic dataset scripts.
+- Pricing subsystem with provider plugins, CLI commands for `portfolio prices`, and configuration helpers.
 
 ## 0.0.1 - Initial scaffolding
 - Established package structure and CLI stub.

--- a/README.md
+++ b/README.md
@@ -2,14 +2,12 @@
 
 This project aims to build an auditable, deterministic portfolio management tool focused on Australian tax rules.
 
-## Stage 2 Status
+## Stage 3 Status
 
-- Domain models and portfolio services implement lot matching, CGT slicing, and brokerage allocation helpers.
-- Transactions recorded via the service automatically create lots, process disposals, and refresh open positions.
-- Persistence layer implemented with interchangeable SQLite and JSON repositories.
-- Automatic schema migrations (001_init) provision the required tables and indexes.
-- Demo seeding script now provisions both backends with example trades and a cached price.
-- Deterministic synthetic dataset generator (`scripts/gen_synth_50k.py`) for performance testing.
+- Pricing subsystem introduced with pluggable providers (manual inline + Yahoo-based default) and disk-backed cache.
+- CLI now exposes `portfolio prices show|refresh|set` for managing cached quotes and manual overrides.
+- Configuration helpers centralised in `portfolio_tool.core.config` to share defaults across CLI/scripts.
+- Existing persistence, domain services, and demo dataset tooling remain available for smoke testing and development.
 
 Run the CLI help to confirm installation:
 
@@ -23,3 +21,7 @@ portfolio --help
 - Run tests: `make test`
 - Generate demo data: `python scripts/seed_demo.py`
 - Build synthetic datasets: `python scripts/gen_synth_50k.py`
+- Manage price cache:
+  - Show cached quotes: `portfolio prices show`
+  - Refresh via provider: `portfolio prices refresh CSL IOZ`
+  - Manually override: `portfolio prices set CSL 245.10 --asof 2024-03-15T16:00:00+10:00`

--- a/portfolio_tool/app/cli.py
+++ b/portfolio_tool/app/cli.py
@@ -2,50 +2,73 @@
 from __future__ import annotations
 
 import sys
+from datetime import datetime
 from pathlib import Path
-from typing import Optional
+from typing import Iterable, Optional
 
 import typer
 from rich import print
 
-APP_NAME = "portfolio"
-DEFAULT_CONFIG_PATH = Path.cwd() / "config.toml"
-DEFAULT_CONFIG_CONTENT = """base_currency = \"AUD\"
-timezone = \"Australia/Brisbane\"
-lot_matching = \"FIFO\"
-brokerage_allocation = \"BUY\"
-[prices]
-provider = \"online_default\"
-cache_ttl_minutes = 15
-stale_price_max_minutes = 60
-exchange_suffix_map = { \"ASX\" = \".AX\" }
-[target_weights]
-CSL = 0.15
-IOZ = 0.20
-[rule_thresholds]
-cgt_window_days = 60
-overweight_band = 0.02
-concentration_limit = 0.25
-loss_threshold_pct = -0.15
-"""
+from ..core.config import ensure_config, load_config
+from ..core.pricing import PricingService
+from ..data import JSONRepository, SQLiteRepository
+from ..plugins.pricing import get_provider
+
+DATA_DIR = Path("data")
 
 
-def ensure_config(path: Path = DEFAULT_CONFIG_PATH) -> Path:
-    """Ensure the default configuration file exists."""
-    if not path.exists():
-        path.write_text(DEFAULT_CONFIG_CONTENT)
-    return path
+def _open_repository(config: dict) -> SQLiteRepository | JSONRepository:
+    """Instantiate the configured repository backend."""
+
+    storage_cfg = config.get("storage", {})
+    backend = (storage_cfg.get("backend") or "sqlite").lower()
+    DATA_DIR.mkdir(exist_ok=True)
+    if backend == "sqlite":
+        path = storage_cfg.get("path") or DATA_DIR / "portfolio.sqlite"
+        return SQLiteRepository(Path(path))
+    if backend == "json":
+        path = storage_cfg.get("path") or DATA_DIR / "portfolio.json"
+        return JSONRepository(Path(path))
+    raise typer.BadParameter(f"Unsupported storage backend: {backend}")
+
+
+def _known_symbols(repo: SQLiteRepository | JSONRepository) -> list[str]:
+    """Return a sorted list of symbols referenced in transactions."""
+
+    rows = repo.list_transactions()
+    return sorted({row["symbol"] for row in rows})
+
+
+def _build_pricing_service(repo, config: dict) -> PricingService:
+    prices_cfg = config.get("prices", {})
+    provider_name = prices_cfg.get("provider", "manual_inline")
+    provider = get_provider(provider_name)
+    timezone = config.get("timezone", "Australia/Brisbane")
+    cache_ttl = prices_cfg.get("cache_ttl_minutes", 15)
+    stale_max = prices_cfg.get("stale_price_max_minutes", 60)
+    suffix_map = prices_cfg.get("exchange_suffix_map", {})
+    return PricingService(
+        repo,
+        provider,
+        cache_ttl_minutes=cache_ttl,
+        stale_price_max_minutes=stale_max,
+        timezone=timezone,
+        exchange_suffix_map=suffix_map,
+    )
 
 
 # Ensure configuration is ready at import time to cover --help invocations.
 ensure_config()
 
 app = typer.Typer(help="Portfolio Tool — Terminal Edition")
+prices_app = typer.Typer(help="Price cache management")
+app.add_typer(prices_app, name="prices")
 
 
 @app.callback(invoke_without_command=True)
 def main(ctx: typer.Context) -> Optional[int]:
     """Application entrypoint that ensures configuration is present."""
+
     ensure_config()
     if ctx.invoked_subcommand is None:
         print(ctx.get_help())
@@ -56,7 +79,72 @@ def main(ctx: typer.Context) -> Optional[int]:
 @app.command()
 def version() -> None:
     """Print the CLI version."""
+
     print("portfolio-tool 0.0.1")
+
+
+def _render_quotes(quotes: Iterable) -> None:
+    if not quotes:
+        print("[yellow]No price data available[/yellow]")
+        return
+    for quote in quotes:
+        stale_flag = " (stale)" if quote.stale else ""
+        print(
+            f"[bold]{quote.symbol}[/bold]: {quote.price:.4f}"
+            f" from {quote.source} @ {quote.asof.isoformat()}{stale_flag}"
+        )
+
+
+@prices_app.command("show")
+def prices_show(symbols: list[str] = typer.Argument(None)) -> None:
+    """Display cached price quotes for the requested symbols."""
+
+    config = load_config()
+    repo = _open_repository(config)
+    try:
+        service = _build_pricing_service(repo, config)
+        targets = symbols or _known_symbols(repo)
+        quotes = service.get_cached(targets)
+        _render_quotes(quotes.values())
+    finally:
+        repo.close()
+
+
+@prices_app.command("refresh")
+def prices_refresh(symbols: list[str] = typer.Argument(None)) -> None:
+    """Refresh live prices using the configured provider."""
+
+    config = load_config()
+    repo = _open_repository(config)
+    try:
+        service = _build_pricing_service(repo, config)
+        targets = symbols or _known_symbols(repo)
+        quotes = service.refresh_prices(targets or None)
+        _render_quotes(quotes.values())
+    finally:
+        repo.close()
+
+
+@prices_app.command("set")
+def prices_set(
+    symbol: str,
+    price: float,
+    asof: Optional[str] = typer.Option(
+        None,
+        help="ISO-8601 timestamp for the manual quote (defaults to now)",
+    ),
+) -> None:
+    """Manually set or override a price quote."""
+
+    config = load_config()
+    repo = _open_repository(config)
+    try:
+        service = _build_pricing_service(repo, config)
+        asof_dt = datetime.fromisoformat(asof) if asof else None
+        quotes = service.set_manual(symbol, price, asof_dt)
+        _render_quotes(quotes.values())
+    finally:
+        repo.close()
 
 
 if __name__ == "__main__":

--- a/portfolio_tool/core/config.py
+++ b/portfolio_tool/core/config.py
@@ -1,0 +1,48 @@
+"""Configuration helpers for the portfolio tool."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import tomllib
+
+DEFAULT_CONFIG_CONTENT = """base_currency = \"AUD\"
+timezone = \"Australia/Brisbane\"
+lot_matching = \"FIFO\"
+brokerage_allocation = \"BUY\"
+[prices]
+provider = \"online_default\"
+cache_ttl_minutes = 15
+stale_price_max_minutes = 60
+exchange_suffix_map = { \"ASX\" = \".AX\" }
+[target_weights]
+CSL = 0.15
+IOZ = 0.20
+[rule_thresholds]
+cgt_window_days = 60
+overweight_band = 0.02
+concentration_limit = 0.25
+loss_threshold_pct = -0.15
+"""
+
+DEFAULT_CONFIG_PATH = Path("config.toml")
+
+
+def ensure_config(path: Path | None = None) -> Path:
+    """Ensure a configuration file exists at *path* and return it."""
+
+    target = Path(path) if path is not None else DEFAULT_CONFIG_PATH
+    if not target.exists():
+        target.write_text(DEFAULT_CONFIG_CONTENT, encoding="utf-8")
+    return target
+
+
+def load_config(path: Path | None = None) -> dict[str, Any]:
+    """Load configuration data from ``config.toml`` as a dictionary."""
+
+    config_path = ensure_config(path)
+    with config_path.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+__all__ = ["ensure_config", "load_config", "DEFAULT_CONFIG_PATH", "DEFAULT_CONFIG_CONTENT"]

--- a/portfolio_tool/core/pricing.py
+++ b/portfolio_tool/core/pricing.py
@@ -1,0 +1,209 @@
+"""Pricing subsystem responsible for live quote retrieval and caching."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Callable, Iterable, Mapping
+
+from zoneinfo import ZoneInfo
+
+from ..data.repo_base import BaseRepository
+from ..plugins.pricing import ProviderPrice, PriceProvider
+from .models import PriceQuote
+
+
+@dataclass(slots=True)
+class CachedRecord:
+    symbol: str
+    asof: datetime
+    price: float
+    source: str
+    fetched_at: datetime
+    stale: bool
+
+
+class PricingService:
+    """Manage price cache persistence and provider integration."""
+
+    def __init__(
+        self,
+        repo: BaseRepository,
+        provider: PriceProvider,
+        *,
+        cache_ttl_minutes: int = 15,
+        stale_price_max_minutes: int = 60,
+        timezone: str = "Australia/Brisbane",
+        exchange_suffix_map: Mapping[str, str] | None = None,
+        now_fn: Callable[[], datetime] | None = None,
+    ) -> None:
+        self.repo = repo
+        self.provider = provider
+        self.cache_ttl = timedelta(minutes=max(cache_ttl_minutes, 0))
+        self.stale_window = timedelta(minutes=max(stale_price_max_minutes, 0))
+        self.tz = ZoneInfo(timezone)
+        self.exchange_suffix_map = {
+            (key or "").upper(): value for key, value in (exchange_suffix_map or {}).items()
+        }
+        self._now = now_fn or (lambda: datetime.now(tz=self.tz))
+        self._exchange_cache: dict[str, str | None] = {}
+
+    # ------------------------------------------------------------------
+    def refresh_prices(self, symbols: list[str] | None = None) -> dict[str, PriceQuote]:
+        """Fetch latest prices for ``symbols`` and store them in the cache."""
+
+        if symbols is None:
+            symbols = []
+        fetch_map = self._build_provider_symbol_map(symbols)
+        if not fetch_map:
+            return {}
+
+        try:
+            provider_results = self.provider.fetch(sorted(set(fetch_map.values())))
+        except Exception:
+            return {}
+
+        now = self._now()
+        quotes: dict[str, PriceQuote] = {}
+        for symbol, provider_symbol in fetch_map.items():
+            data = provider_results.get(provider_symbol)
+            if not data:
+                continue
+            record = self._record_from_provider(symbol, data, now)
+            self._persist_record(record)
+            quotes[symbol] = self._quote_from_record(record)
+        return quotes
+
+    # ------------------------------------------------------------------
+    def get_cached(self, symbols: list[str]) -> dict[str, PriceQuote]:
+        """Return cached price quotes for the requested ``symbols``."""
+
+        records = self.repo.get_prices(symbols)
+        now = self._now()
+        quotes: dict[str, PriceQuote] = {}
+        for symbol in symbols:
+            data = records.get(symbol)
+            if not data:
+                continue
+            record = self._record_from_row(symbol, data)
+            stale = record.stale or (now - record.fetched_at) > self.cache_ttl
+            stale = stale or (now - record.asof) > self.stale_window
+            quotes[symbol] = PriceQuote(
+                symbol=symbol,
+                asof=record.asof,
+                price=record.price,
+                source=record.source,
+                stale=stale,
+            )
+        return quotes
+
+    # ------------------------------------------------------------------
+    def set_manual(self, symbol: str, price, asof) -> dict[str, PriceQuote]:
+        """Set a manual price entry that takes precedence over provider data."""
+
+        now = self._now()
+        asof_dt = self._ensure_datetime(asof) if asof else now
+        record = CachedRecord(
+            symbol=symbol,
+            asof=asof_dt.astimezone(self.tz),
+            price=float(price),
+            source="manual",
+            fetched_at=now,
+            stale=False,
+        )
+        self._persist_record(record)
+        return {symbol: self._quote_from_record(record)}
+
+    # ------------------------------------------------------------------
+    def _ensure_datetime(self, value) -> datetime:
+        if isinstance(value, datetime):
+            return value if value.tzinfo else value.replace(tzinfo=self.tz)
+        if isinstance(value, str):
+            parsed = datetime.fromisoformat(value)
+            return parsed if parsed.tzinfo else parsed.replace(tzinfo=self.tz)
+        raise TypeError("Expected datetime or ISO8601 string")
+
+    def _record_from_row(self, symbol: str, row: Mapping[str, object]) -> CachedRecord:
+        stale_value = row.get("stale", 0)
+        try:
+            stale_flag = bool(int(stale_value))
+        except (TypeError, ValueError):
+            stale_flag = bool(stale_value)
+        return CachedRecord(
+            symbol=symbol,
+            asof=self._ensure_datetime(row["asof"]),
+            price=float(row["price"]),
+            source=str(row["source"]),
+            fetched_at=self._ensure_datetime(row["fetched_at"]),
+            stale=stale_flag,
+        )
+
+    def _persist_record(self, record: CachedRecord) -> None:
+        stale_flag = int(record.fetched_at - record.asof > self.stale_window)
+        self.repo.upsert_price(
+            {
+                "symbol": record.symbol,
+                "asof": record.asof.isoformat(),
+                "price": record.price,
+                "source": record.source,
+                "fetched_at": record.fetched_at.isoformat(),
+                "stale": stale_flag,
+            }
+        )
+
+    def _quote_from_record(self, record: CachedRecord) -> PriceQuote:
+        now = self._now()
+        stale = (now - record.fetched_at) > self.cache_ttl
+        stale = stale or (now - record.asof) > self.stale_window
+        return PriceQuote(
+            symbol=record.symbol,
+            asof=record.asof,
+            price=record.price,
+            source=record.source,
+            stale=stale,
+        )
+
+    def _record_from_provider(
+        self, symbol: str, data: ProviderPrice, now: datetime
+    ) -> CachedRecord:
+        asof = data.asof.astimezone(self.tz)
+        return CachedRecord(
+            symbol=symbol,
+            asof=asof,
+            price=data.price,
+            source=data.source,
+            fetched_at=now,
+            stale=False,
+        )
+
+    def _build_provider_symbol_map(self, symbols: Iterable[str]) -> dict[str, str]:
+        mapping: dict[str, str] = {}
+        if not symbols:
+            return mapping
+        existing = self.repo.get_prices(symbols)
+        for symbol in symbols:
+            existing_record = existing.get(symbol)
+            if existing_record and existing_record.get("source") == "manual":
+                continue
+            provider_symbol = self._provider_symbol_for(symbol)
+            mapping[symbol] = provider_symbol
+        return mapping
+
+    def _provider_symbol_for(self, symbol: str) -> str:
+        exchange = self._exchange_for_symbol(symbol)
+        suffix = self.exchange_suffix_map.get(exchange.upper()) if exchange else None
+        if suffix and not symbol.endswith(suffix):
+            return f"{symbol}{suffix}"
+        return symbol
+
+    def _exchange_for_symbol(self, symbol: str) -> str | None:
+        if symbol in self._exchange_cache:
+            return self._exchange_cache[symbol]
+        rows = self.repo.list_transactions(symbol=symbol, limit=1, order="desc")
+        exchange = None
+        if rows:
+            exchange = rows[0].get("exchange")
+        self._exchange_cache[symbol] = exchange.upper() if isinstance(exchange, str) else None
+        return self._exchange_cache[symbol]
+
+
+__all__ = ["PricingService", "CachedRecord"]

--- a/portfolio_tool/plugins/pricing/__init__.py
+++ b/portfolio_tool/plugins/pricing/__init__.py
@@ -1,0 +1,26 @@
+"""Pricing providers registry."""
+
+from .manual_inline import ManualInlineProvider
+from .online_default import OnlineDefaultProvider
+from .provider_base import PriceProvider, ProviderPrice
+
+_PROVIDERS = {
+    ManualInlineProvider.name: ManualInlineProvider,
+    OnlineDefaultProvider.name: OnlineDefaultProvider,
+}
+
+
+def get_provider(name: str, **kwargs) -> PriceProvider:
+    cls = _PROVIDERS.get(name)
+    if cls is None:
+        raise ValueError(f"Unknown price provider: {name}")
+    return cls(**kwargs)
+
+
+__all__ = [
+    "get_provider",
+    "ManualInlineProvider",
+    "OnlineDefaultProvider",
+    "PriceProvider",
+    "ProviderPrice",
+]

--- a/portfolio_tool/plugins/pricing/manual_inline.py
+++ b/portfolio_tool/plugins/pricing/manual_inline.py
@@ -1,0 +1,41 @@
+"""Manual inline price provider used for offline workflows."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Iterable, Mapping
+
+from zoneinfo import ZoneInfo
+
+from .provider_base import ProviderPrice
+
+
+class ManualInlineProvider:
+    """In-memory provider backed by a mutable mapping of quotes."""
+
+    name = "manual_inline"
+
+    def __init__(
+        self,
+        quotes: Mapping[str, ProviderPrice] | None = None,
+        *,
+        timezone: str = "Australia/Brisbane",
+    ) -> None:
+        self._tz = ZoneInfo(timezone)
+        self._quotes: dict[str, ProviderPrice] = dict(quotes or {})
+
+    def set_quote(self, symbol: str, price: float, asof: datetime | None = None) -> None:
+        """Update the manual quote cache for *symbol*."""
+
+        asof = (asof or datetime.now(tz=self._tz)).astimezone(self._tz)
+        self._quotes[symbol] = ProviderPrice(
+            symbol=symbol,
+            price=float(price),
+            asof=asof,
+            source=self.name,
+        )
+
+    def fetch(self, symbols: Iterable[str]) -> dict[str, ProviderPrice]:
+        return {symbol: self._quotes[symbol] for symbol in symbols if symbol in self._quotes}
+
+
+__all__ = ["ManualInlineProvider"]

--- a/portfolio_tool/plugins/pricing/online_default.py
+++ b/portfolio_tool/plugins/pricing/online_default.py
@@ -1,0 +1,77 @@
+"""HTTP-powered pricing provider using the Yahoo Finance quote endpoint."""
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+from typing import Callable, Iterable
+
+import httpx
+
+from .provider_base import ProviderPrice
+
+
+class OnlineDefaultProvider:
+    """Fetch quotes from a public HTTP endpoint with basic retries."""
+
+    name = "online_default"
+
+    def __init__(
+        self,
+        *,
+        client_factory: Callable[[], httpx.Client] | None = None,
+        base_url: str = "https://query1.finance.yahoo.com/v7/finance/quote",
+        retries: int = 2,
+        backoff_seconds: float = 0.5,
+    ) -> None:
+        self._client_factory = client_factory or (lambda: httpx.Client(timeout=5.0))
+        self._base_url = base_url
+        self._retries = max(retries, 0)
+        self._backoff = max(backoff_seconds, 0.0)
+
+    def fetch(self, symbols: Iterable[str]) -> dict[str, ProviderPrice]:
+        symbols_list = [symbol for symbol in symbols if symbol]
+        if not symbols_list:
+            return {}
+        params = {"symbols": ",".join(symbols_list)}
+        attempt = 0
+        last_exc: Exception | None = None
+        while attempt <= self._retries:
+            try:
+                with self._client_factory() as client:
+                    response = client.get(self._base_url, params=params)
+                    response.raise_for_status()
+                    data = response.json()
+                    return self._parse_response(data)
+            except Exception as exc:  # pragma: no cover - defensive loop
+                last_exc = exc
+                attempt += 1
+                if attempt > self._retries:
+                    break
+                time.sleep(self._backoff)
+        if last_exc is not None:
+            raise last_exc
+        return {}
+
+    def _parse_response(self, payload: dict) -> dict[str, ProviderPrice]:
+        quotes = {}
+        results = payload.get("quoteResponse", {}).get("result", [])
+        for item in results:
+            symbol = item.get("symbol")
+            price = item.get("regularMarketPrice")
+            timestamp = item.get("regularMarketTime")
+            if not symbol or price is None or timestamp is None:
+                continue
+            asof = _timestamp_to_datetime(timestamp)
+            quotes[symbol] = ProviderPrice(
+                symbol=symbol,
+                price=float(price),
+                asof=asof,
+                source=self.name,
+            )
+        return quotes
+
+
+def _timestamp_to_datetime(value: int | float) -> datetime:
+    return datetime.fromtimestamp(float(value), tz=timezone.utc)
+
+__all__ = ["OnlineDefaultProvider"]

--- a/portfolio_tool/plugins/pricing/provider_base.py
+++ b/portfolio_tool/plugins/pricing/provider_base.py
@@ -1,0 +1,28 @@
+"""Price provider protocol definitions."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable, Protocol
+
+
+@dataclass(slots=True)
+class ProviderPrice:
+    """Container returned by price providers."""
+
+    symbol: str
+    price: float
+    asof: datetime
+    source: str
+
+
+class PriceProvider(Protocol):
+    """Protocol implemented by pricing provider plugins."""
+
+    name: str
+
+    def fetch(self, symbols: Iterable[str]) -> dict[str, ProviderPrice]:
+        """Return price quotes keyed by the provider's symbol string."""
+
+
+__all__ = ["ProviderPrice", "PriceProvider"]

--- a/portfolio_tool/tests/test_pricing.py
+++ b/portfolio_tool/tests/test_pricing.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+from zoneinfo import ZoneInfo
+
+from portfolio_tool.core.models import Transaction
+from portfolio_tool.core.pricing import PricingService
+from portfolio_tool.core.services import PortfolioService
+from portfolio_tool.data.repo_json import JSONRepository
+from portfolio_tool.plugins.pricing import ProviderPrice
+from portfolio_tool.plugins.pricing.online_default import OnlineDefaultProvider
+
+
+class DummyProvider:
+    name = "dummy"
+
+    def __init__(self, price: float, *, tz: ZoneInfo) -> None:
+        self.tz = tz
+        self.price = price
+        self.asof = datetime(2024, 1, 1, 10, 0, tzinfo=tz)
+
+    def fetch(self, symbols):
+        return {
+            symbol: ProviderPrice(
+                symbol=symbol,
+                price=self.price,
+                asof=self.asof,
+                source=self.name,
+            )
+            for symbol in symbols
+        }
+
+
+def _service(tmp_path, provider, now):
+    repo = JSONRepository(tmp_path / "pricing.json")
+    return repo, PricingService(
+        repo,
+        provider,
+        cache_ttl_minutes=15,
+        stale_price_max_minutes=60,
+        timezone="Australia/Brisbane",
+        now_fn=lambda: now[0],
+    )
+
+
+def aware(year, month, day, hour=0, minute=0):
+    tz = ZoneInfo("Australia/Brisbane")
+    return datetime(year, month, day, hour, minute, tzinfo=tz)
+
+
+def test_refresh_and_cache_roundtrip(tmp_path):
+    tz = ZoneInfo("Australia/Brisbane")
+    provider = DummyProvider(250.0, tz=tz)
+    now = [aware(2024, 1, 1, 11, 0)]
+    repo, service = _service(tmp_path, provider, now)
+
+    quotes = service.refresh_prices(["CSL"])
+    assert quotes["CSL"].price == pytest.approx(250.0)
+    cached = service.get_cached(["CSL"])
+    assert not cached["CSL"].stale
+    repo.close()
+
+
+def test_cache_ttl_and_stale_logic(tmp_path):
+    tz = ZoneInfo("Australia/Brisbane")
+    provider = DummyProvider(200.0, tz=tz)
+    now = [aware(2024, 1, 1, 9, 0)]
+    repo, service = _service(tmp_path, provider, now)
+    service.refresh_prices(["CSL"])
+    now[0] = now[0] + timedelta(minutes=61)
+    cached = service.get_cached(["CSL"])
+    assert cached["CSL"].stale is True
+    repo.close()
+
+
+def test_manual_override_preserved_during_refresh(tmp_path):
+    tz = ZoneInfo("Australia/Brisbane")
+    provider = DummyProvider(210.0, tz=tz)
+    now = [aware(2024, 1, 1, 9, 0)]
+    repo, service = _service(tmp_path, provider, now)
+    service.refresh_prices(["CSL"])
+    now[0] = now[0] + timedelta(minutes=1)
+    service.set_manual("CSL", 305.5, aware(2024, 1, 1, 9, 1))
+    provider.price = 190.0
+    provider.asof = aware(2024, 1, 1, 9, 2)
+    now[0] = now[0] + timedelta(minutes=1)
+    service.refresh_prices(["CSL"])
+    cached = service.get_cached(["CSL"])
+    assert cached["CSL"].price == pytest.approx(305.5)
+    repo.close()
+
+
+def test_online_default_provider_parses_http_payload():
+    captured = {}
+
+    class DummyClient:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def get(self, url, params=None):
+            captured["url"] = url
+            captured["params"] = params
+
+            class DummyResponse:
+                def raise_for_status(self):
+                    return None
+
+                def json(self):
+                    return {
+                        "quoteResponse": {
+                            "result": [
+                                {
+                                    "symbol": "CSL.AX",
+                                    "regularMarketPrice": 255.55,
+                                    "regularMarketTime": 1700000000,
+                                }
+                            ]
+                        }
+                    }
+
+            return DummyResponse()
+
+    provider = OnlineDefaultProvider(client_factory=DummyClient)
+    quotes = provider.fetch(["CSL.AX"])
+    quote = quotes["CSL.AX"]
+    assert quote.price == pytest.approx(255.55)
+    assert captured["params"]["symbols"] == "CSL.AX"
+
+
+def test_positions_without_prices_show_none(tmp_path):
+    repo = JSONRepository(tmp_path / "positions.json")
+    service = PortfolioService(repo)
+    txn = Transaction(
+        dt=aware(2024, 1, 1, 10, 0),
+        type="BUY",
+        symbol="CSL",
+        qty=5.0,
+        price=100.0,
+        fees=0.0,
+    )
+    service.record_trade(txn)
+    positions = service.compute_positions(prices={})
+    assert positions[0].mv is None
+    repo.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "typer[all]>=0.9",
     "tomli-w>=1.0.0",
     "tzdata>=2023.3",
+    "httpx>=0.25",
 ]
 
 [project.optional-dependencies]

--- a/scripts/seed_demo.py
+++ b/scripts/seed_demo.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
-from portfolio_tool.app.cli import ensure_config
+from portfolio_tool.core.config import ensure_config
 from portfolio_tool.data import JSONRepository, SQLiteRepository
 
 _TZ = ZoneInfo("Australia/Brisbane")


### PR DESCRIPTION
## Summary
- add configuration helpers and pricing service with TTL-aware cache and manual overrides
- provide manual and online pricing providers plus CLI commands for showing, refreshing, and setting prices
- cover pricing logic with dedicated tests and document the new workflows in README and changelog

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ddf09478048322a75b3e1aef5f5755