### PR TITLE
Add Textual TUI for portfolio management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Pricing subsystem with provider plugins, CLI commands for `portfolio prices`, and configuration helpers.
 - Reporting engine with CLI commands for positions, lots, and CGT calendar plus CSV/Markdown exporters and golden fixtures.
 - Actionables rules engine with starter rule pack, persisted lifecycle (open/done/snooze), and CLI management commands.
+- Textual TUI with dashboard, trades, positions, lots, CGT, actionables, prices, and config tabs plus modal forms and paged tables.
 
 ## 0.0.1 - Initial scaffolding
 - Established package structure and CLI stub.

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 This project aims to build an auditable, deterministic portfolio management tool focused on Australian tax rules.
 
-## Stage 5 Status
+## Stage 6 Status
 
-- Actionables engine evaluates CGT windows, portfolio weights, concentrations, unrealised losses, stale prices, and trailing-stop coverage.
-- CLI now supports `portfolio actionables` for listing, snoozing, and completing persisted follow-up items.
-- Reporting exports (positions, lots, CGT calendar) continue to provide deterministic CSV/Markdown outputs with provenance fields.
-- Pricing subsystem, configuration helpers, and data tooling remain available for smoke testing and development.
+- Textual TUI (`portfolio tui`) featuring dashboard, trades, positions, lots, CGT calendar, actionables, prices, and config tabs with paged tables.
+- Keyboard shortcuts: `F1` help overlay, `Q` quit, `R` refresh, `/` search focus, `A` add, `E` edit, `D` delete, `S` save/export/manual actions.
+- Trades tab supports add/edit/delete with validated forms and automatic portfolio rebuilds; price tab shows provider status, last refresh, and manual overrides.
+- Actionables, pricing, and reporting services remain available for CLI flows alongside the new TUI.
 
 Run the CLI help to confirm installation:
 
@@ -29,3 +29,4 @@ portfolio --help
   - Positions: `portfolio positions --refresh-prices --export csv reports/positions.csv`
   - Lots ledger (single symbol): `portfolio lots CSL --export md reports/lots.md`
   - CGT calendar (60-day window): `portfolio cgt-calendar --window 60`
+- Launch the Textual TUI: `portfolio tui` (or `./scripts/run_tui.sh`)

--- a/portfolio_tool/app/cli.py
+++ b/portfolio_tool/app/cli.py
@@ -556,5 +556,15 @@ def prices_set(
         repo.close()
 
 
+@app.command()
+def tui() -> None:
+    """Launch the Textual TUI."""
+
+    ensure_config()
+    from .tui import PortfolioApp
+
+    PortfolioApp().run()
+
+
 if __name__ == "__main__":
     sys.exit(app())

--- a/portfolio_tool/app/tui/__init__.py
+++ b/portfolio_tool/app/tui/__init__.py
@@ -1,0 +1,4 @@
+"""Textual TUI package."""
+from .app import PortfolioApp, run
+
+__all__ = ["PortfolioApp", "run"]

--- a/portfolio_tool/app/tui/app.py
+++ b/portfolio_tool/app/tui/app.py
@@ -1,0 +1,255 @@
+"""Textual application entrypoint for the portfolio tool."""
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from textual.app import App, ComposeResult
+from textual.containers import Container
+from textual.screen import ModalScreen
+from textual.widgets import Footer, Header, Static, TabbedContent, TabPane
+
+from ...core.config import DEFAULT_CONFIG_PATH, ensure_config, load_config
+from ...core.pricing import PricingService
+from ...core.reports import ReportingService
+from ...core.rules import ActionableService
+from ...core.services import PortfolioService
+from ...data import JSONRepository, SQLiteRepository
+from ...plugins.pricing import get_provider
+from .views import (
+    ActionablesView,
+    CGTCalendarView,
+    ConfigView,
+    DashboardView,
+    LotsView,
+    PositionsView,
+    PricesView,
+    TradesView,
+)
+
+
+@dataclass
+class AppServices:
+    repo: Any
+    portfolio: PortfolioService
+    reporting: ReportingService
+    pricing: PricingService
+    actionables: ActionableService
+    config: dict
+    config_path: Path
+
+
+class HelpModal(ModalScreen[None]):
+    """Simple overlay listing key bindings."""
+
+    def compose(self) -> ComposeResult:
+        text = (
+            "[b]Portfolio Tool — Key Bindings[/b]\n"
+            "F1 Help  |  Q Quit  |  R Refresh  |  / Search\n"
+            "A Add  |  E Edit  |  D Delete  |  S Save/Export"
+        )
+        yield Container(Static(text, id="help-text"), id="help-container")
+
+
+class PortfolioApp(App[None]):
+    CSS = ""
+    BINDINGS = [
+        ("f1", "help", "Help"),
+        ("q", "quit", "Quit"),
+        ("r", "refresh", "Refresh"),
+        ("/", "focus_search", "Search"),
+        ("a", "add", "Add"),
+        ("e", "edit", "Edit"),
+        ("d", "delete", "Delete"),
+        ("s", "save", "Save/Export"),
+        ("tab", "focus_next", "Next"),
+        ("shift+tab", "focus_previous", "Previous"),
+    ]
+
+    def __init__(
+        self,
+        *,
+        config_path: Path | None = None,
+        data_dir: Path | None = None,
+    ) -> None:
+        super().__init__()
+        self._config_path = Path(config_path or DEFAULT_CONFIG_PATH)
+        self._data_dir = Path(data_dir or "data")
+        self.services: AppServices | None = None
+        self._view_map: dict[str, Any] = {}
+        self._active_view = None
+
+        self.dashboard_view = DashboardView()
+        self.trades_view = TradesView()
+        self.positions_view = PositionsView()
+        self.lots_view = LotsView()
+        self.cgt_view = CGTCalendarView()
+        self.actionables_view = ActionablesView()
+        self.prices_view = PricesView()
+        self.config_view = ConfigView()
+
+    # ------------------------------------------------------------------
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=True)
+        with TabbedContent(id="main-tabs"):
+            with TabPane("Dashboard", id="tab-dashboard"):
+                yield self.dashboard_view
+            with TabPane("Trades", id="tab-trades"):
+                yield self.trades_view
+            with TabPane("Positions", id="tab-positions"):
+                yield self.positions_view
+            with TabPane("Lots", id="tab-lots"):
+                yield self.lots_view
+            with TabPane("CGT", id="tab-cgt"):
+                yield self.cgt_view
+            with TabPane("Actionables", id="tab-actionables"):
+                yield self.actionables_view
+            with TabPane("Prices", id="tab-prices"):
+                yield self.prices_view
+            with TabPane("Config", id="tab-config"):
+                yield self.config_view
+        yield Footer()
+
+    # ------------------------------------------------------------------
+    def on_mount(self) -> None:
+        self.services = self._build_services()
+        self._view_map = {
+            "tab-dashboard": self.dashboard_view,
+            "tab-trades": self.trades_view,
+            "tab-positions": self.positions_view,
+            "tab-lots": self.lots_view,
+            "tab-cgt": self.cgt_view,
+            "tab-actionables": self.actionables_view,
+            "tab-prices": self.prices_view,
+            "tab-config": self.config_view,
+        }
+        self._active_view = self.dashboard_view
+        for view in self._view_map.values():
+            view.refresh_view()
+
+    # ------------------------------------------------------------------
+    def on_unmount(self) -> None:
+        if self.services:
+            self.services.repo.close()
+
+    # ------------------------------------------------------------------
+    def _build_services(self) -> AppServices:
+        config_file = ensure_config(self._config_path)
+        config = load_config(config_file)
+        repo = self._open_repository(config)
+        portfolio = PortfolioService(
+            repo,
+            timezone=config.get("timezone", "Australia/Brisbane"),
+            lot_matching=config.get("lot_matching", "FIFO"),
+            brokerage_allocation=config.get("brokerage_allocation", "BUY"),
+        )
+        reporting = ReportingService(
+            repo,
+            timezone=config.get("timezone", "Australia/Brisbane"),
+            base_currency=config.get("base_currency", "AUD"),
+            portfolio_service=portfolio,
+        )
+        pricing = PricingService(
+            repo,
+            get_provider(config.get("prices", {}).get("provider", "manual_inline")),
+            cache_ttl_minutes=config.get("prices", {}).get("cache_ttl_minutes", 15),
+            stale_price_max_minutes=config.get("prices", {}).get("stale_price_max_minutes", 60),
+            timezone=config.get("timezone", "Australia/Brisbane"),
+            exchange_suffix_map=config.get("prices", {}).get("exchange_suffix_map", {}),
+        )
+        actionables = ActionableService(
+            repo,
+            portfolio_service=portfolio,
+            reporting_service=reporting,
+            pricing_service=pricing,
+            timezone=config.get("timezone", "Australia/Brisbane"),
+            target_weights=config.get("target_weights", {}),
+            rule_thresholds=config.get("rule_thresholds", {}),
+        )
+        return AppServices(
+            repo=repo,
+            portfolio=portfolio,
+            reporting=reporting,
+            pricing=pricing,
+            actionables=actionables,
+            config=config,
+            config_path=config_file,
+        )
+
+    # ------------------------------------------------------------------
+    def _open_repository(self, config: dict) -> Any:
+        storage_cfg = config.get("storage", {})
+        backend = (storage_cfg.get("backend") or "sqlite").lower()
+        self._data_dir.mkdir(parents=True, exist_ok=True)
+        if backend == "sqlite":
+            path = storage_cfg.get("path") or self._data_dir / "portfolio.sqlite"
+            return SQLiteRepository(Path(path))
+        if backend == "json":
+            path = storage_cfg.get("path") or self._data_dir / "portfolio.json"
+            return JSONRepository(Path(path))
+        raise RuntimeError(f"Unsupported storage backend: {backend}")
+
+    # ------------------------------------------------------------------
+    def _current_view(self):
+        return self._active_view
+
+    # ------------------------------------------------------------------
+    async def _invoke_view(self, name: str) -> None:
+        view = self._current_view()
+        if not view:
+            return
+        handler = getattr(view, name, None)
+        if not handler:
+            return
+        result = handler()
+        if inspect.isawaitable(result):
+            await result
+
+    # ------------------------------------------------------------------
+    async def action_add(self) -> None:
+        await self._invoke_view("handle_add")
+
+    async def action_edit(self) -> None:
+        await self._invoke_view("handle_edit")
+
+    async def action_delete(self) -> None:
+        await self._invoke_view("handle_delete")
+
+    async def action_save(self) -> None:
+        await self._invoke_view("handle_save")
+
+    async def action_refresh(self) -> None:
+        await self._invoke_view("handle_refresh")
+        view = self._current_view()
+        if view:
+            view.refresh_view()
+
+    def action_focus_search(self) -> None:
+        view = self._current_view()
+        if view:
+            view.focus_search()
+
+    def action_help(self) -> None:
+        self.push_screen(HelpModal())
+
+    def action_quit(self) -> None:
+        self.exit()
+
+    # ------------------------------------------------------------------
+    def on_tabbed_content_tab_activated(
+        self, event: TabbedContent.TabActivated
+    ) -> None:
+        view = self._view_map.get(event.tab.id)
+        if view:
+            self._active_view = view
+            view.refresh_view()
+
+
+def run() -> None:
+    PortfolioApp().run()
+
+
+if __name__ == "__main__":
+    run()

--- a/portfolio_tool/app/tui/views/__init__.py
+++ b/portfolio_tool/app/tui/views/__init__.py
@@ -1,0 +1,20 @@
+"""View exports for the Textual app."""
+from .actionables import ActionablesView
+from .cgt import CGTCalendarView
+from .config import ConfigView
+from .dashboard import DashboardView
+from .lots import LotsView
+from .positions import PositionsView
+from .prices import PricesView
+from .trades import TradesView
+
+__all__ = [
+    "DashboardView",
+    "TradesView",
+    "PositionsView",
+    "LotsView",
+    "CGTCalendarView",
+    "ActionablesView",
+    "PricesView",
+    "ConfigView",
+]

--- a/portfolio_tool/app/tui/views/actionables.py
+++ b/portfolio_tool/app/tui/views/actionables.py
@@ -1,0 +1,97 @@
+"""Actionables management view."""
+from __future__ import annotations
+
+from typing import Any
+
+from ..widgets.forms import SnoozeForm
+from ..widgets.toasts import show_toast
+from .base import TableView
+
+
+class ActionablesView(TableView):
+    def __init__(self) -> None:
+        super().__init__(
+            title="Actionables",
+            columns=[
+                ("id", "ID"),
+                ("type", "Type"),
+                ("symbol", "Symbol"),
+                ("message", "Message"),
+                ("status", "Status"),
+                ("snoozed_until", "Snoozed Until"),
+                ("updated_at", "Updated"),
+            ],
+            key_field="id",
+        )
+        self._rows: list[dict[str, Any]] = []
+
+    def on_mount(self) -> None:
+        self.set_loader(self._load_page)
+        super().on_mount()
+
+    def _compute_rows(self) -> None:
+        services = self.services
+        if services is None:
+            self._rows = []
+            return
+        items = services.actionables.evaluate_rules(include_snoozed=True)
+        self._rows = [
+            {
+                "id": item.id,
+                "type": item.type,
+                "symbol": item.symbol,
+                "message": item.message,
+                "status": item.status,
+                "snoozed_until": item.snoozed_until.isoformat() if item.snoozed_until else "",
+                "updated_at": item.updated_at.isoformat(),
+            }
+            for item in items
+        ]
+
+    def _load_page(self, page: int, size: int, query: str):
+        self._compute_rows()
+        data = self._rows
+        if query:
+            q = query.upper()
+            data = [row for row in data if q in str(row.get("symbol", "")).upper() or q in str(row.get("message", "")).upper()]
+        total = len(data)
+        start = page * size
+        end = start + size
+        return data[start:end], total
+
+    async def handle_add(self) -> None:
+        self.refresh_view()
+        show_toast(self.app, "Rules evaluated", severity="information")
+
+    async def handle_edit(self) -> None:
+        services = self.services
+        if services is None:
+            return
+        selected = self.table.get_selected_row()
+        if not selected:
+            show_toast(self.app, "Select an actionable to snooze", severity="warning")
+            return
+        form = SnoozeForm()
+        days = await self.app.push_screen_wait(form)
+        if not days:
+            return
+        actionable_id = int(selected["id"])
+        services.actionables.snooze(actionable_id, int(days))
+        self.refresh_view()
+        show_toast(self.app, f"Snoozed actionable {actionable_id}", severity="success")
+
+    def handle_delete(self) -> None:
+        services = self.services
+        if services is None:
+            return
+        selected = self.table.get_selected_row()
+        if not selected:
+            show_toast(self.app, "Select an actionable to complete", severity="warning")
+            return
+        actionable_id = int(selected["id"])
+        services.actionables.complete(actionable_id)
+        self.refresh_view()
+        show_toast(self.app, f"Completed actionable {actionable_id}", severity="success")
+
+
+__all__ = ["ActionablesView"]

--- a/portfolio_tool/app/tui/views/base.py
+++ b/portfolio_tool/app/tui/views/base.py
@@ -1,0 +1,116 @@
+"""Base view components for the Textual TUI."""
+from __future__ import annotations
+
+from typing import Sequence
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.reactive import reactive
+from textual.widgets import Input, Static
+
+from ..widgets.tables import Loader, PagedTable
+
+
+class PortfolioView(Vertical):
+    """Base class for all portfolio views."""
+
+    @property
+    def services(self):  # pragma: no cover - simple delegation
+        from ..app import PortfolioApp
+
+        app = self.app
+        if isinstance(app, PortfolioApp):
+            return app.services
+        return None
+
+    def refresh_view(self) -> None:  # pragma: no cover - default no-op
+        """Refresh the view's data."""
+
+    def focus_search(self) -> None:  # pragma: no cover - default no-op
+        """Focus the search control if available."""
+
+    def handle_add(self) -> None:  # pragma: no cover - default no-op
+        """Handle Add action for the current view."""
+
+    def handle_edit(self) -> None:  # pragma: no cover - default no-op
+        """Handle Edit action for the current view."""
+
+    def handle_delete(self) -> None:  # pragma: no cover - default no-op
+        """Handle Delete action for the current view."""
+
+    def handle_save(self) -> None:  # pragma: no cover - default no-op
+        """Handle Save/Export action for the current view."""
+
+    def handle_refresh(self) -> None:  # pragma: no cover - default no-op
+        """Handle refresh action for the current view."""
+
+
+class TableView(PortfolioView):
+    """Helper view that displays a paged table with search/filter."""
+
+    search_query = reactive("")
+
+    def __init__(
+        self,
+        *,
+        title: str,
+        columns: Sequence[tuple[str, str]],
+        key_field: str = "id",
+        page_size: int = 20,
+    ) -> None:
+        super().__init__(id=f"view-{title.lower().replace(' ', '-')}")
+        self._title = title
+        self._table = PagedTable(columns=columns, key_field=key_field, page_size=page_size)
+        self._status = Static("", classes="table-status")
+        self._search = Input(placeholder="Search…", id=f"{self.id}-search")
+        self._loader: Loader | None = None
+
+    @property
+    def table(self) -> PagedTable:
+        return self._table
+
+    @property
+    def status_label(self) -> Static:
+        return self._status
+
+    def compose(self) -> ComposeResult:
+        yield Static(self._title, classes="view-title")
+        with Horizontal(classes="search-row"):
+            yield self._search
+            yield self._status
+        yield self._table
+
+    def set_loader(self, loader: Loader) -> None:
+        self._loader = loader
+        self._table.set_loader(self._load_rows)
+
+    def _load_rows(self, page: int, size: int, query: str):
+        if not self._loader:
+            return [], 0
+        return self._loader(page, size, query)
+
+    def refresh_view(self) -> None:
+        self._table.reload()
+        self._status.update(self.status_text())
+
+    def handle_refresh(self) -> None:
+        self.refresh_view()
+
+    def focus_search(self) -> None:
+        self._search.focus()
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        if event.input is self._search:
+            self.search_query = event.value
+            self._table.set_filter(self.search_query)
+            self._status.update(self.status_text())
+
+    def on_mount(self) -> None:
+        self._table.reload()
+        self._status.update(self.status_text())
+
+    def status_text(self) -> str:
+        return self._table.page_info()
+
+
+__all__ = ["PortfolioView", "TableView"]

--- a/portfolio_tool/app/tui/views/cgt.py
+++ b/portfolio_tool/app/tui/views/cgt.py
@@ -1,0 +1,69 @@
+"""CGT calendar view."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from zoneinfo import ZoneInfo
+
+from ..widgets.toasts import show_toast
+from .base import TableView
+
+
+class CGTCalendarView(TableView):
+    def __init__(self) -> None:
+        super().__init__(
+            title="CGT Calendar",
+            columns=[
+                ("lot_id", "Lot"),
+                ("symbol", "Symbol"),
+                ("threshold_date", "Threshold"),
+                ("days_until", "Days"),
+                ("eligible_for_discount", "Eligible"),
+                ("qty_remaining", "Qty"),
+            ],
+            key_field="lot_id",
+        )
+        self._rows: list[dict[str, Any]] = []
+        self._window_days = 60
+
+    def on_mount(self) -> None:
+        self.set_loader(self._load_page)
+        super().on_mount()
+
+    def _compute_rows(self) -> None:
+        services = self.services
+        if services is None:
+            self._rows = []
+            return
+        tz = ZoneInfo(services.config.get("timezone", "Australia/Brisbane"))
+        reporting = services.reporting
+        self._rows = reporting.cgt_calendar(
+            asof=datetime.now(tz=tz),
+            window_days=self._window_days,
+        )
+
+    def _load_page(self, page: int, size: int, query: str):
+        self._compute_rows()
+        data = self._rows
+        if query:
+            q = query.upper()
+            data = [row for row in data if q in str(row.get("symbol", "")).upper()]
+        total = len(data)
+        start = page * size
+        end = start + size
+        return data[start:end], total
+
+    def handle_add(self) -> None:
+        options = [30, 60, 90]
+        idx = options.index(self._window_days)
+        self._window_days = options[(idx + 1) % len(options)]
+        self.refresh_view()
+        show_toast(self.app, f"CGT window set to {self._window_days} days", severity="information")
+
+    def status_text(self) -> str:
+        return f"Window {self._window_days} days | {self.table.page_info()}"
+
+
+
+__all__ = ["CGTCalendarView"]

--- a/portfolio_tool/app/tui/views/config.py
+++ b/portfolio_tool/app/tui/views/config.py
@@ -1,0 +1,94 @@
+"""Configuration view."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import ast
+import tomli_w
+
+from ..widgets.forms import ConfigForm
+from ..widgets.toasts import show_toast
+from .base import TableView
+
+
+def _flatten(prefix: str, value: Any):
+    if isinstance(value, dict):
+        for key, sub in sorted(value.items()):
+            new_prefix = f"{prefix}.{key}" if prefix else str(key)
+            yield from _flatten(new_prefix, sub)
+    else:
+        yield prefix, value
+
+
+class ConfigView(TableView):
+    def __init__(self) -> None:
+        super().__init__(
+            title="Config",
+            columns=[("key", "Key"), ("value", "Value")],
+            key_field="key",
+        )
+        self._rows: list[dict[str, Any]] = []
+
+    def on_mount(self) -> None:
+        self.set_loader(self._load_page)
+        super().on_mount()
+
+    def _compute_rows(self) -> None:
+        services = self.services
+        if services is None:
+            self._rows = []
+            return
+        rows: list[dict[str, Any]] = []
+        for key, value in _flatten("", services.config):
+            rows.append({"key": key, "value": value})
+        rows.sort(key=lambda item: item["key"])
+        self._rows = rows
+
+    def _load_page(self, page: int, size: int, query: str):
+        self._compute_rows()
+        data = self._rows
+        if query:
+            q = query.upper()
+            data = [row for row in data if q in row["key"].upper()]
+        total = len(data)
+        start = page * size
+        end = start + size
+        return data[start:end], total
+
+    async def handle_edit(self) -> None:
+        services = self.services
+        if services is None:
+            return
+        selected = self.table.get_selected_row()
+        if not selected:
+            show_toast(self.app, "Select a config entry", severity="warning")
+            return
+        key = str(selected["key"])
+        value = str(selected["value"])
+        form = ConfigForm(key, value)
+        result = await self.app.push_screen_wait(form)
+        if not result:
+            return
+        self._update_config(result["key"], result["value"], services)
+        self.refresh_view()
+        show_toast(self.app, f"Updated {result['key']}", severity="success")
+
+    def _update_config(self, key: str, value: str, services) -> None:
+        parts = key.split(".") if key else []
+        target = services.config
+        for part in parts[:-1]:
+            target = target.setdefault(part, {})
+        parsed: Any
+        try:
+            parsed = ast.literal_eval(value)
+        except Exception:
+            parsed = value
+        if parts:
+            target[parts[-1]] = parsed
+        path: Path = services.config_path
+        with path.open("wb") as fh:
+            tomli_w.dump(services.config, fh)
+
+
+__all__ = ["ConfigView"]

--- a/portfolio_tool/app/tui/views/dashboard.py
+++ b/portfolio_tool/app/tui/views/dashboard.py
@@ -1,0 +1,59 @@
+"""Dashboard view showing high level portfolio metrics."""
+from __future__ import annotations
+
+from datetime import datetime
+
+from textual.app import ComposeResult
+from textual.widgets import Static
+from zoneinfo import ZoneInfo
+
+from .base import PortfolioView
+
+
+class DashboardView(PortfolioView):
+    """Display a quick snapshot of the portfolio."""
+
+    def __init__(self) -> None:
+        super().__init__(id="view-dashboard")
+        self._summary = Static("", classes="dashboard-summary")
+
+    def compose(self) -> ComposeResult:
+        yield Static("Dashboard", classes="view-title")
+        yield self._summary
+
+    def refresh_view(self) -> None:
+        services = self.services
+        if services is None:
+            return
+        tz_name = services.config.get("timezone", "Australia/Brisbane")
+        tz = ZoneInfo(tz_name)
+        pricing = services.pricing
+        repo = services.repo
+        reporting = services.reporting
+        actionables = services.actionables
+
+        symbols = sorted({row["symbol"] for row in repo.list_lots(only_open=True)})
+        quotes = pricing.get_cached(symbols)
+        snapshot = reporting.positions_snapshot(datetime.now(tz=tz), quotes)
+        total_mv = 0.0
+        total_cost = 0.0
+        holdings = 0
+        for row in snapshot:
+            if row.get("symbol") == "TOTAL":
+                total_mv = float(row.get("market_value") or 0.0)
+                total_cost = float(row.get("cost_base") or 0.0)
+            else:
+                holdings += 1
+        unrealised = total_mv - total_cost
+        actionables_list = actionables.list_actionables()
+        open_items = sum(1 for item in actionables_list if item.status != "DONE")
+        summary = (
+            f"Holdings: [bold]{holdings}[/bold]\n"
+            f"Market Value: [bold]{total_mv:,.2f} {services.config.get('base_currency', 'AUD')}[/bold]\n"
+            f"Unrealised P/L: [bold]{unrealised:,.2f}[/bold]\n"
+            f"Actionables: [bold]{open_items} open[/bold]"
+        )
+        self._summary.update(summary)
+
+
+__all__ = ["DashboardView"]

--- a/portfolio_tool/app/tui/views/lots.py
+++ b/portfolio_tool/app/tui/views/lots.py
@@ -1,0 +1,55 @@
+"""Lots ledger view."""
+from __future__ import annotations
+
+from typing import Any
+
+from ..widgets.toasts import show_toast
+from .base import TableView
+
+
+class LotsView(TableView):
+    def __init__(self) -> None:
+        super().__init__(
+            title="Lots",
+            columns=[
+                ("lot_id", "Lot"),
+                ("symbol", "Symbol"),
+                ("acquired_at", "Acquired"),
+                ("threshold_date", "CGT Threshold"),
+                ("original_qty", "Original Qty"),
+                ("qty_remaining", "Qty Remaining"),
+                ("cost_base_remaining", "Cost Base"),
+                ("status", "Status"),
+            ],
+            key_field="lot_id",
+        )
+        self._rows: list[dict[str, Any]] = []
+
+    def on_mount(self) -> None:
+        self.set_loader(self._load_page)
+        super().on_mount()
+
+    def _compute_rows(self) -> None:
+        services = self.services
+        if services is None:
+            self._rows = []
+            return
+        reporting = services.reporting
+        self._rows = reporting.lots_ledger()
+
+    def _load_page(self, page: int, size: int, query: str):
+        self._compute_rows()
+        data = self._rows
+        if query:
+            q = query.upper()
+            data = [row for row in data if q in str(row.get("symbol", "")).upper()]
+        total = len(data)
+        start = page * size
+        end = start + size
+        return data[start:end], total
+
+    def handle_add(self) -> None:
+        show_toast(self.app, "Lots derive from trades. Add trades instead.", severity="information")
+
+
+__all__ = ["LotsView"]

--- a/portfolio_tool/app/tui/views/positions.py
+++ b/portfolio_tool/app/tui/views/positions.py
@@ -1,0 +1,64 @@
+"""Positions view showing current holdings."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from zoneinfo import ZoneInfo
+
+from ..widgets.toasts import show_toast
+from .base import TableView
+
+
+class PositionsView(TableView):
+    def __init__(self) -> None:
+        super().__init__(
+            title="Positions",
+            columns=[
+                ("symbol", "Symbol"),
+                ("quantity", "Qty"),
+                ("avg_cost", "Avg Cost"),
+                ("cost_base", "Cost Base"),
+                ("price", "Price"),
+                ("market_value", "Market Value"),
+                ("weight_pct", "Weight %"),
+            ],
+            key_field="symbol",
+        )
+        self._rows: list[dict[str, Any]] = []
+
+    def on_mount(self) -> None:
+        self.set_loader(self._load_page)
+        super().on_mount()
+
+    def _compute_rows(self) -> None:
+        services = self.services
+        if services is None:
+            self._rows = []
+            return
+        tz = ZoneInfo(services.config.get("timezone", "Australia/Brisbane"))
+        repo = services.repo
+        reporting = services.reporting
+        pricing = services.pricing
+        symbols = sorted({row["symbol"] for row in repo.list_lots(only_open=True)})
+        quotes = pricing.get_cached(symbols)
+        snapshot = reporting.positions_snapshot(datetime.now(tz=tz), quotes)
+        self._rows = snapshot
+
+    def _load_page(self, page: int, size: int, query: str):
+        self._compute_rows()
+        data = self._rows
+        if query:
+            q = query.upper()
+            data = [row for row in data if q in str(row.get("symbol", "")).upper()]
+        total = len(data)
+        start = page * size
+        end = start + size
+        page_rows = data[start:end]
+        return page_rows, total
+
+    def handle_save(self) -> None:
+        show_toast(self.app, "Use CLI exports for detailed reports", severity="information")
+
+
+__all__ = ["PositionsView"]

--- a/portfolio_tool/app/tui/views/prices.py
+++ b/portfolio_tool/app/tui/views/prices.py
@@ -1,0 +1,132 @@
+"""Prices view for cached quotes."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from zoneinfo import ZoneInfo
+
+from ..widgets.forms import ManualPriceForm
+from ..widgets.toasts import show_toast
+from .base import TableView
+
+
+class PricesView(TableView):
+    def __init__(self) -> None:
+        super().__init__(
+            title="Prices",
+            columns=[
+                ("symbol", "Symbol"),
+                ("price", "Price"),
+                ("asof", "As-of"),
+                ("source", "Source"),
+                ("stale", "Stale"),
+            ],
+            key_field="symbol",
+        )
+        self._rows: list[dict[str, Any]] = []
+        self._provider = ""
+        self._last_refresh: datetime | None = None
+
+    def on_mount(self) -> None:
+        self.set_loader(self._load_page)
+        super().on_mount()
+
+    def _known_symbols(self) -> list[str]:
+        services = self.services
+        if services is None:
+            return []
+        repo = services.repo
+        symbols = {row["symbol"] for row in repo.list_transactions()}
+        symbols.update({row["symbol"] for row in repo.list_lots(only_open=True)})
+        return sorted(symbols)
+
+    def _compute_rows(self) -> None:
+        services = self.services
+        if services is None:
+            self._rows = []
+            self._provider = ""
+            self._last_refresh = None
+            return
+        pricing = services.pricing
+        tz = ZoneInfo(services.config.get("timezone", "Australia/Brisbane"))
+        symbols = self._known_symbols()
+        quotes = pricing.get_cached(symbols)
+        self._rows = []
+        latest: datetime | None = None
+        for symbol in symbols:
+            quote = quotes.get(symbol)
+            if quote:
+                latest = max(latest, quote.asof) if latest else quote.asof
+                self._rows.append(
+                    {
+                        "symbol": symbol,
+                        "price": quote.price,
+                        "asof": quote.asof.astimezone(tz).isoformat(),
+                        "source": quote.source,
+                        "stale": "yes" if quote.stale else "no",
+                    }
+                )
+            else:
+                self._rows.append(
+                    {
+                        "symbol": symbol,
+                        "price": None,
+                        "asof": "-",
+                        "source": "(none)",
+                        "stale": "",
+                    }
+                )
+        self._provider = type(pricing.provider).__name__
+        self._last_refresh = latest
+
+    def _load_page(self, page: int, size: int, query: str):
+        self._compute_rows()
+        data = self._rows
+        if query:
+            q = query.upper()
+            data = [row for row in data if q in str(row.get("symbol", "")).upper()]
+        total = len(data)
+        start = page * size
+        end = start + size
+        return data[start:end], total
+
+    def status_text(self) -> str:
+        last = self._last_refresh.isoformat() if self._last_refresh else "n/a"
+        return f"Provider {self._provider} | Last quote {last} | {self.table.page_info()}"
+
+    def handle_refresh(self) -> None:
+        services = self.services
+        if services is None:
+            return
+        symbols = self._known_symbols()
+        quotes = services.pricing.refresh_prices(symbols or None)
+        if not quotes:
+            show_toast(self.app, "No quotes refreshed", severity="warning")
+        else:
+            show_toast(self.app, f"Refreshed {len(quotes)} quotes", severity="success")
+        self.refresh_view()
+
+    async def handle_save(self) -> None:
+        services = self.services
+        if services is None:
+            return
+        selected = self.table.get_selected_row()
+        symbol = selected.get("symbol") if selected else None
+        form = ManualPriceForm(
+            symbol=symbol,
+            timezone=services.config.get("timezone", "Australia/Brisbane"),
+        )
+        result = await self.app.push_screen_wait(form)
+        if not result:
+            return
+        services.pricing.set_manual(
+            result["symbol"],
+            result["price"],
+            result["asof"],
+        )
+        show_toast(self.app, f"Manual price set for {result['symbol']}", severity="success")
+        self.refresh_view()
+
+
+__all__ = ["PricesView"]

--- a/portfolio_tool/app/tui/views/trades.py
+++ b/portfolio_tool/app/tui/views/trades.py
@@ -1,0 +1,180 @@
+"""Trades view providing add/edit/delete operations."""
+from __future__ import annotations
+
+from typing import Any
+
+from portfolio_tool.core.models import Transaction
+from ..widgets.forms import TradeForm
+from ..widgets.toasts import show_toast
+from .base import TableView
+
+
+class TradesView(TableView):
+    """List transactions with editing capabilities."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            title="Trades",
+            columns=[
+                ("id", "ID"),
+                ("dt", "When"),
+                ("type", "Type"),
+                ("symbol", "Symbol"),
+                ("qty", "Qty"),
+                ("price", "Price"),
+                ("fees", "Fees"),
+                ("broker_ref", "Broker Ref"),
+            ],
+            key_field="id",
+        )
+        self._cache: list[dict[str, Any]] = []
+        self._dirty = True
+
+    def on_mount(self) -> None:
+        services = self.services
+        if services is None:
+            return
+        self.set_loader(self._load_page)
+        super().on_mount()
+
+    def _ensure_cache(self) -> None:
+        if not self._dirty:
+            return
+        services = self.services
+        if services is None:
+            return
+        repo = services.repo
+        rows = repo.list_transactions(order="desc")
+        self._cache = rows
+        self._dirty = False
+
+    def _load_page(self, page: int, size: int, query: str):
+        self._ensure_cache()
+        data = self._cache
+        if query:
+            q = query.upper()
+            data = [
+                row
+                for row in data
+                if q in str(row.get("symbol", "")).upper()
+                or q in str(row.get("type", "")).upper()
+                or q in str(row.get("notes", "")).upper()
+            ]
+        total = len(data)
+        start = page * size
+        end = start + size
+        page_rows = data[start:end]
+        display_rows: list[dict[str, Any]] = []
+        for row in page_rows:
+            display_rows.append(
+                {
+                    "id": row["id"],
+                    "dt": row["dt"],
+                    "type": row["type"],
+                    "symbol": row["symbol"],
+                    "qty": float(row["qty"]),
+                    "price": float(row["price"]),
+                    "fees": float(row.get("fees", 0.0)),
+                    "broker_ref": row.get("broker_ref"),
+                    "_raw": row,
+                }
+            )
+        return display_rows, total
+
+    async def handle_add(self) -> None:
+        services = self.services
+        if services is None:
+            return
+        form = TradeForm(
+            title="Add Trade",
+            timezone=services.config.get("timezone", "Australia/Brisbane"),
+        )
+        result = await self.app.push_screen_wait(form)
+        if not result:
+            return
+        txn = Transaction(
+            dt=result["dt"],
+            type=result["type"],
+            symbol=result["symbol"],
+            qty=float(result["qty"]),
+            price=float(result["price"]),
+            fees=float(result["fees"]),
+            broker_ref=result.get("broker_ref"),
+            notes=result.get("notes"),
+            exchange=result.get("exchange"),
+        )
+        services.portfolio.record_trade(txn)
+        self._dirty = True
+        services.actionables.evaluate_rules(include_snoozed=True)
+        self.refresh_view()
+        show_toast(self.app, "Trade recorded", severity="success")
+
+    async def handle_edit(self) -> None:
+        services = self.services
+        if services is None:
+            return
+        selected = self.table.get_selected_row()
+        if not selected:
+            show_toast(self.app, "Select a trade to edit", severity="warning")
+            return
+        raw = selected.get("_raw") or {}
+        initial = {
+            "type": raw.get("type"),
+            "symbol": raw.get("symbol"),
+            "qty": raw.get("qty"),
+            "price": raw.get("price"),
+            "fees": raw.get("fees"),
+            "dt": raw.get("dt"),
+            "broker_ref": raw.get("broker_ref"),
+            "notes": raw.get("notes"),
+            "exchange": raw.get("exchange"),
+        }
+        form = TradeForm(
+            title=f"Edit Trade #{raw.get('id')}",
+            timezone=services.config.get("timezone", "Australia/Brisbane"),
+            initial=initial,
+        )
+        result = await self.app.push_screen_wait(form)
+        if not result:
+            return
+        repo = services.repo
+        txn_id = int(raw["id"])
+        repo.update_transaction(
+            txn_id,
+            {
+                "dt": result["dt"].isoformat(),
+                "type": result["type"],
+                "symbol": result["symbol"],
+                "qty": float(result["qty"]),
+                "price": float(result["price"]),
+                "fees": float(result["fees"]),
+                "broker_ref": result.get("broker_ref"),
+                "notes": result.get("notes"),
+                "exchange": result.get("exchange"),
+            },
+        )
+        services.portfolio.rebuild_state()
+        self._dirty = True
+        services.actionables.evaluate_rules(include_snoozed=True)
+        self.refresh_view()
+        show_toast(self.app, "Trade updated", severity="success")
+
+    def handle_delete(self) -> None:
+        services = self.services
+        if services is None:
+            return
+        selected = self.table.get_selected_row()
+        if not selected:
+            show_toast(self.app, "Select a trade to delete", severity="warning")
+            return
+        txn_id = int(selected.get("id"))
+        repo = services.repo
+        repo.delete_transaction(txn_id)
+        services.portfolio.rebuild_state()
+        self._dirty = True
+        services.actionables.evaluate_rules(include_snoozed=True)
+        self.refresh_view()
+        show_toast(self.app, f"Deleted trade #{txn_id}", severity="warning")
+
+
+__all__ = ["TradesView"]

--- a/portfolio_tool/app/tui/widgets/forms.py
+++ b/portfolio_tool/app/tui/widgets/forms.py
@@ -1,0 +1,279 @@
+"""Form widgets used by the TUI."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Mapping
+
+from textual.app import ComposeResult
+from textual.containers import Grid
+from textual.screen import ModalScreen
+from textual.widgets import Button, Input, Label, Select
+from zoneinfo import ZoneInfo
+
+TRADE_TYPES = [
+    ("Buy", "BUY"),
+    ("Sell", "SELL"),
+    ("Dividend Reinvestment", "DRP"),
+]
+
+
+class TradeForm(ModalScreen[dict[str, object]]):
+    """Modal form to add or edit a trade."""
+
+    def __init__(
+        self,
+        *,
+        title: str,
+        timezone: str,
+        initial: Mapping[str, object] | None = None,
+    ) -> None:
+        super().__init__()
+        self._title = title
+        self._timezone = timezone
+        self._initial = dict(initial or {})
+        self._error_label: Label | None = None
+
+    def compose(self) -> ComposeResult:
+        grid = Grid(id="trade-form")
+        grid.styles.grid_columns = "repeat(2, 1fr)"
+        grid.styles.grid_rows = "auto auto auto auto auto auto auto auto auto"
+        grid.styles.gap = (1, 2)
+        grid.styles.padding = (1, 2)
+        grid.styles.border = ("round", "blue")
+
+        yield Label(self._title, id="form-title")
+        yield Select(TRADE_TYPES, id="trade-type", prompt="Type")
+        yield Input(placeholder="Symbol", id="symbol")
+        yield Input(placeholder="Quantity", id="qty")
+        yield Input(placeholder="Price", id="price")
+        yield Input(placeholder="Fees", id="fees")
+        yield Input(placeholder="When (ISO8601)", id="dt")
+        yield Input(placeholder="Exchange", id="exchange")
+        yield Input(placeholder="Broker Ref", id="broker_ref")
+        yield Input(placeholder="Notes", id="notes")
+        self._error_label = Label("", id="form-error")
+        yield self._error_label
+        yield Button("Save", variant="success", id="save")
+        yield Button("Cancel", variant="error", id="cancel")
+
+    def on_mount(self) -> None:
+        select = self.query_one("#trade-type", Select)
+        select.value = str(self._initial.get("type", "BUY"))
+        for field in ["symbol", "qty", "price", "fees", "dt", "exchange", "broker_ref", "notes"]:
+            widget = self.query_one(f"#{field}", Input)
+            value = self._initial.get(field)
+            if value is None:
+                continue
+            widget.value = str(value)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "cancel":
+            self.dismiss(None)
+            return
+        if event.button.id == "save":
+            payload = self._gather_data()
+            if payload is not None:
+                self.dismiss(payload)
+
+    def _gather_data(self) -> dict[str, object] | None:
+        try:
+            trade_type = str(self.query_one("#trade-type", Select).value or "").upper()
+            symbol = self.query_one("#symbol", Input).value.strip().upper()
+            qty = float(self.query_one("#qty", Input).value)
+            price = float(self.query_one("#price", Input).value)
+            fees_input = self.query_one("#fees", Input).value or "0"
+            fees = float(fees_input)
+            dt_raw = self.query_one("#dt", Input).value.strip()
+            if not dt_raw:
+                raise ValueError("Date/time is required")
+            dt = datetime.fromisoformat(dt_raw)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=ZoneInfo(self._timezone))
+            exchange = self.query_one("#exchange", Input).value.strip().upper() or None
+            broker_ref = self.query_one("#broker_ref", Input).value.strip() or None
+            notes = self.query_one("#notes", Input).value.strip() or None
+        except Exception as exc:  # pragma: no cover - conversion errors
+            if self._error_label is not None:
+                self._error_label.update(f"[red]Error:[/red] {exc}")
+            return None
+
+        if trade_type not in {value for _, value in TRADE_TYPES}:
+            if self._error_label is not None:
+                self._error_label.update("[red]Invalid trade type[/red]")
+            return None
+        if not symbol:
+            if self._error_label is not None:
+                self._error_label.update("[red]Symbol is required[/red]")
+            return None
+        if qty <= 0:
+            if self._error_label is not None:
+                self._error_label.update("[red]Quantity must be positive[/red]")
+            return None
+        if price < 0:
+            if self._error_label is not None:
+                self._error_label.update("[red]Price cannot be negative[/red]")
+            return None
+
+        return {
+            "type": trade_type,
+            "symbol": symbol,
+            "qty": qty,
+            "price": price,
+            "fees": fees,
+            "dt": dt,
+            "exchange": exchange,
+            "broker_ref": broker_ref,
+            "notes": notes,
+        }
+
+
+class SnoozeForm(ModalScreen[int]):
+    """Collect snooze duration for an actionable."""
+
+    def __init__(self, *, title: str = "Snooze Actionable") -> None:
+        super().__init__()
+        self._title = title
+        self._error: Label | None = None
+
+    def compose(self) -> ComposeResult:
+        container = Grid(id="snooze-form")
+        container.styles.grid_rows = "auto auto auto"
+        container.styles.padding = (1, 2)
+        container.styles.gap = (1, 1)
+        container.styles.border = ("round", "magenta")
+        yield Label(self._title)
+        yield Input(placeholder="Days", id="days")
+        self._error = Label("", id="snooze-error")
+        yield self._error
+        yield Button("Confirm", variant="success", id="confirm")
+        yield Button("Cancel", variant="error", id="cancel")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "cancel":
+            self.dismiss(None)
+            return
+        if event.button.id == "confirm":
+            days_raw = self.query_one("#days", Input).value.strip()
+            try:
+                days = int(days_raw)
+            except ValueError:
+                if self._error is not None:
+                    self._error.update("[red]Enter a whole number of days[/red]")
+                return
+            if days <= 0:
+                if self._error is not None:
+                    self._error.update("[red]Days must be positive[/red]")
+                return
+            self.dismiss(days)
+
+
+class ManualPriceForm(ModalScreen[dict[str, object]]):
+    """Collect manual price details."""
+
+    def __init__(
+        self,
+        *,
+        title: str = "Set Manual Price",
+        symbol: str | None = None,
+        timezone: str = "Australia/Brisbane",
+    ) -> None:
+        super().__init__()
+        self._title = title
+        self._symbol = symbol
+        self._timezone = timezone
+        self._error: Label | None = None
+
+    def compose(self) -> ComposeResult:
+        grid = Grid(id="price-form")
+        grid.styles.grid_rows = "auto auto auto auto"
+        grid.styles.padding = (1, 2)
+        grid.styles.gap = (1, 1)
+        grid.styles.border = ("round", "green")
+        yield Label(self._title)
+        yield Input(placeholder="Symbol", id="symbol")
+        yield Input(placeholder="Price", id="price")
+        yield Input(placeholder="As-of (ISO8601 optional)", id="asof")
+        self._error = Label("", id="price-error")
+        yield self._error
+        yield Button("Save", variant="success", id="save")
+        yield Button("Cancel", variant="error", id="cancel")
+
+    def on_mount(self) -> None:
+        if self._symbol:
+            self.query_one("#symbol", Input).value = self._symbol
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "cancel":
+            self.dismiss(None)
+            return
+        if event.button.id == "save":
+            payload = self._gather()
+            if payload:
+                self.dismiss(payload)
+
+    def _gather(self) -> dict[str, object] | None:
+        symbol = self.query_one("#symbol", Input).value.strip().upper()
+        price_raw = self.query_one("#price", Input).value.strip()
+        asof_raw = self.query_one("#asof", Input).value.strip()
+        if not symbol:
+            if self._error is not None:
+                self._error.update("[red]Symbol is required[/red]")
+            return None
+        try:
+            price = float(price_raw)
+        except ValueError:
+            if self._error is not None:
+                self._error.update("[red]Price must be numeric[/red]")
+            return None
+        asof: datetime | None = None
+        if asof_raw:
+            try:
+                dt = datetime.fromisoformat(asof_raw)
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=ZoneInfo(self._timezone))
+                asof = dt
+            except Exception:
+                if self._error is not None:
+                    self._error.update("[red]Invalid as-of timestamp[/red]")
+                return None
+        return {"symbol": symbol, "price": price, "asof": asof}
+
+
+class ConfigForm(ModalScreen[dict[str, str]]):
+    """Prompt for configuration updates."""
+
+    def __init__(self, key: str, value: str) -> None:
+        super().__init__()
+        self._key = key
+        self._value = value
+        self._error: Label | None = None
+
+    def compose(self) -> ComposeResult:
+        grid = Grid(id="config-form")
+        grid.styles.grid_rows = "auto auto auto"
+        grid.styles.padding = (1, 2)
+        grid.styles.gap = (1, 1)
+        grid.styles.border = ("round", "yellow")
+        yield Label(f"Update {self._key}")
+        input_widget = Input(id="value")
+        input_widget.value = self._value
+        yield input_widget
+        self._error = Label("", id="config-error")
+        yield self._error
+        yield Button("Save", variant="success", id="save")
+        yield Button("Cancel", variant="error", id="cancel")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "cancel":
+            self.dismiss(None)
+            return
+        if event.button.id == "save":
+            value = self.query_one("#value", Input).value
+            if not value:
+                if self._error is not None:
+                    self._error.update("[red]Value is required[/red]")
+                return
+            self.dismiss({"key": self._key, "value": value})
+
+
+__all__ = ["TradeForm", "SnoozeForm", "ManualPriceForm", "ConfigForm"]

--- a/portfolio_tool/app/tui/widgets/tables.py
+++ b/portfolio_tool/app/tui/widgets/tables.py
@@ -1,0 +1,111 @@
+"""Reusable paged table widget for the TUI."""
+from __future__ import annotations
+
+from typing import Callable, Sequence
+
+from textual.widgets import DataTable
+
+Loader = Callable[[int, int, str], tuple[Sequence[dict[str, object]], int]]
+
+
+class PagedTable(DataTable):
+    """DataTable with simple pagination support."""
+
+    def __init__(
+        self,
+        *,
+        columns: Sequence[tuple[str, str]],
+        key_field: str = "id",
+        page_size: int = 20,
+    ) -> None:
+        super().__init__(zebra_stripes=True)
+        self._columns = list(columns)
+        self._key_field = key_field
+        self._page_size = max(page_size, 1)
+        self._loader: Loader | None = None
+        self._page = 0
+        self._total = 0
+        self._filter = ""
+        self._row_cache: dict[str, dict[str, object]] = {}
+
+    # ------------------------------------------------------------------
+    def _setup_columns(self) -> None:
+        for key, title in self._columns:
+            self.add_column(title, key=key)
+
+    def on_mount(self) -> None:
+        if not self.columns:
+            self.clear()
+            self._setup_columns()
+
+    # ------------------------------------------------------------------
+    def set_loader(self, loader: Loader) -> None:
+        self._loader = loader
+
+    # ------------------------------------------------------------------
+    def set_filter(self, text: str) -> None:
+        self._filter = text.strip().upper()
+        self._page = 0
+        self.reload()
+
+    # ------------------------------------------------------------------
+    def reload(self) -> None:
+        if not self._loader:
+            return
+        rows, total = self._loader(self._page, self._page_size, self._filter)
+        self._total = int(total)
+        self._row_cache.clear()
+        self.clear(columns=True)
+        self._setup_columns()
+        for idx, row in enumerate(rows):
+            key_value = row.get(self._key_field, f"row-{self._page}-{idx}")
+            row_key = str(key_value)
+            values: list[str] = []
+            for key, _ in self._columns:
+                value = row.get(key)
+                if value is None:
+                    values.append("")
+                elif isinstance(value, float):
+                    values.append(f"{value:,.2f}")
+                else:
+                    values.append(str(value))
+            self.add_row(*values, key=row_key)
+            self._row_cache[row_key] = dict(row)
+        if self.row_count:
+            try:
+                self.cursor_type = "row"
+                self.move_cursor(row=0, column=0)
+            except Exception:  # pragma: no cover - best effort
+                pass
+
+    # ------------------------------------------------------------------
+    def get_selected_row(self) -> dict[str, object] | None:
+        row_key = self.cursor_row
+        if row_key is None:
+            return None
+        return self._row_cache.get(str(row_key))
+
+    # ------------------------------------------------------------------
+    def page_info(self) -> str:
+        if not self._loader:
+            return ""
+        start = self._page * self._page_size + 1 if self.row_count else 0
+        end = self._page * self._page_size + self.row_count
+        return f"{start}-{end} of {self._total}"
+
+    # ------------------------------------------------------------------
+    def next_page(self) -> None:
+        if (self._page + 1) * self._page_size >= max(self._total, self.row_count):
+            return
+        self._page += 1
+        self.reload()
+
+    # ------------------------------------------------------------------
+    def previous_page(self) -> None:
+        if self._page == 0:
+            return
+        self._page -= 1
+        self.reload()
+
+
+__all__ = ["PagedTable", "Loader"]

--- a/portfolio_tool/app/tui/widgets/toasts.py
+++ b/portfolio_tool/app/tui/widgets/toasts.py
@@ -1,0 +1,16 @@
+"""Toast helpers for the Textual application."""
+from __future__ import annotations
+
+from textual.app import App
+
+
+def show_toast(app: App, message: str, *, severity: str = "information") -> None:
+    """Display a non-blocking toast notification."""
+
+    try:
+        app.notify(message, severity=severity)
+    except Exception:  # pragma: no cover - fallback for older Textual versions
+        app.log(message)
+
+
+__all__ = ["show_toast"]

--- a/portfolio_tool/tests/test_tui.py
+++ b/portfolio_tool/tests/test_tui.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import asyncio
+
+from portfolio_tool.app.tui.app import PortfolioApp
+from portfolio_tool.core.config import DEFAULT_CONFIG_CONTENT
+
+
+def test_tui_app_starts(tmp_path):
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        DEFAULT_CONFIG_CONTENT
+        + "\n[storage]\nbackend='json'\npath='portfolio.json'\n",
+        encoding="utf-8",
+    )
+    app = PortfolioApp(config_path=config_path, data_dir=tmp_path)
+
+    async def run() -> None:
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert pilot.app.services is not None
+            assert pilot.app.services.repo is not None
+
+    asyncio.run(run())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
     "tomli-w>=1.0.0",
     "tzdata>=2023.3",
     "httpx>=0.25",
+    "rich>=13.7",
+    "textual>=0.58",
 ]
 
 [project.optional-dependencies]

--- a/scripts/run_tui.sh
+++ b/scripts/run_tui.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+PYTHON=${PYTHON:-python}
+exec "$PYTHON" -m portfolio_tool.app.tui.app "$@"


### PR DESCRIPTION
## Summary
- introduce a Textual-based PortfolioApp with tabbed dashboard, trades, positions, lots, CGT, actionables, prices, and config views
- build reusable paged table, modal form widgets, and dedicated view modules to support add/edit/delete, manual prices, and config updates
- expose a `portfolio tui` CLI entry point, add run script, and document/test the new interface

## Testing
- pytest -q
- portfolio tui --help

------
https://chatgpt.com/codex/tasks/task_e_68de093619508322b3c0310e02f44f4c