### PR TITLE
Add python launcher for single-command startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Run the CLI help to confirm installation:
 portfolio --help
 ```
 
+You can also launch the tool with a single command from the project root:
+
+```bash
+python main.py
+```
+
 ## Development
 
 - Create a virtual environment: `make venv`

--- a/main.py
+++ b/main.py
@@ -1,0 +1,51 @@
+"""Convenience entrypoint for the Portfolio Tool application.
+
+This module allows the project to be launched with a single command::
+
+    python main.py
+
+When invoked without additional arguments the Textual TUI is launched.
+Command-line arguments are forwarded to the Typer CLI so existing flows such
+as ``python main.py positions`` remain available.
+"""
+from __future__ import annotations
+
+import sys
+from typing import Iterable, Sequence
+
+from typer.main import get_command
+
+from portfolio_tool.app.cli import app as portfolio_app
+
+_cli = get_command(portfolio_app)
+
+
+def _run_cli(argv: Sequence[str]) -> int:
+    """Execute the Typer CLI with the provided arguments."""
+
+    try:
+        _cli.main(args=list(argv), prog_name="portfolio", standalone_mode=False)
+    except SystemExit as exc:  # pragma: no cover - mirrors Typer behaviour
+        return int(exc.code or 0)
+    return 0
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    """Launch the Portfolio Tool.
+
+    Parameters
+    ----------
+    argv:
+        Optional iterable of arguments (excluding the program name). When not
+        supplied, :data:`sys.argv` is used. Running the launcher without
+        arguments defaults to the TUI for a streamlined experience.
+    """
+
+    args = list(argv if argv is not None else sys.argv[1:])
+    if not args:
+        args = ["tui"]
+    return _run_cli(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation hook
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a repository-level `main.py` launcher that defaults to the TUI when run without arguments
- document the new single-command startup flow in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68def8d6e7bc8322a8758a9d7c1a5139