### PR TITLE
Add optional Textual compatibility layer

### DIFF
--- a/portfolio_tool/app/tui/_textual.py
+++ b/portfolio_tool/app/tui/_textual.py
@@ -1,0 +1,65 @@
+"""Compat imports for Textual with fallback to local stubs."""
+from __future__ import annotations
+
+try:  # pragma: no cover - exercised indirectly in tests
+    from textual.app import App, ComposeResult
+    from textual.containers import Container, Grid, Horizontal, Vertical
+    from textual.reactive import reactive
+    from textual.screen import ModalScreen
+    from textual.widgets import (
+        Button,
+        DataTable,
+        Footer,
+        Header,
+        Input,
+        Label,
+        Select,
+        Static,
+        TabbedContent,
+        TabPane,
+    )
+    HAVE_TEXTUAL = True
+except ModuleNotFoundError:  # pragma: no cover - textual optional
+    from ._textual_stub import (  # type: ignore[assignment]
+        App,
+        Button,
+        ComposeResult,
+        Container,
+        DataTable,
+        Footer,
+        Grid,
+        Header,
+        Horizontal,
+        Input,
+        Label,
+        ModalScreen,
+        Reactive as reactive,
+        Select,
+        Static,
+        TabbedContent,
+        TabPane,
+        Vertical,
+    )
+    HAVE_TEXTUAL = False
+
+__all__ = [
+    "App",
+    "Button",
+    "ComposeResult",
+    "Container",
+    "DataTable",
+    "Footer",
+    "Grid",
+    "Header",
+    "Horizontal",
+    "Input",
+    "Label",
+    "ModalScreen",
+    "HAVE_TEXTUAL",
+    "reactive",
+    "Select",
+    "Static",
+    "TabbedContent",
+    "TabPane",
+    "Vertical",
+]

--- a/portfolio_tool/app/tui/_textual_stub.py
+++ b/portfolio_tool/app/tui/_textual_stub.py
@@ -8,48 +8,182 @@ unit tests exercise (mainly the ability to run the app and access services).
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
-from typing import Any, AsyncIterator, Iterable
+from types import SimpleNamespace
+from typing import Any, AsyncIterator, Iterable, Sequence
 
 
 class ComposeResult(list):
     """Minimal stand-in used only for typing."""
 
 
-class _BaseWidget:
-    def __init__(self, *children: Any, **kwargs: Any) -> None:  # noqa: D401
+class _Styles(SimpleNamespace):
+    """Very small object used to store ad-hoc style attributes."""
+
+
+class Widget:
+    """Base widget used to emulate the Textual API surface."""
+
+    def __init__(
+        self,
+        *children: Any,
+        id: str | None = None,
+        classes: str | None = None,
+        **kwargs: Any,
+    ) -> None:
         self.children: Iterable[Any] = children
+        self.id = id
+        self.classes = classes
         self.kwargs = kwargs
+        self.styles = _Styles()
+        self.app: "App | None" = None
+        self._value: Any = None
+
+    def focus(self) -> None:  # pragma: no cover - behaviourless stub
+        """No-op focus helper."""
+
+    def update(self, value: Any) -> None:  # pragma: no cover - behaviourless stub
+        """Store a value for later inspection in tests."""
+
+        self._value = value
 
 
-class Container(_BaseWidget):
+class Container(Widget):
     pass
 
 
-class Static(_BaseWidget):
+class Grid(Container):
     pass
 
 
-class Header(_BaseWidget):
+class Static(Container):
     pass
 
 
-class Footer(_BaseWidget):
+class Header(Container):
     pass
 
 
-class TabbedContent(_BaseWidget):
+class Footer(Container):
     pass
 
 
-class TabPane(_BaseWidget):
+class TabbedContent(Container):
     pass
 
 
-class ModalScreen:
+class TabPane(Container):
+    pass
+
+
+class Horizontal(Container):
+    pass
+
+
+class Vertical(Container):
+    pass
+
+
+class Button(Widget):
+    def __init__(self, *children: Any, id: str | None = None, variant: str | None = None, **kwargs: Any) -> None:  # noqa: D401,E501
+        super().__init__(*children, id=id, **kwargs)
+        self.variant = variant
+
+
+class Input(Widget):
+    def __init__(self, *children: Any, placeholder: str | None = None, id: str | None = None, **kwargs: Any) -> None:  # noqa: D401,E501
+        super().__init__(*children, id=id, **kwargs)
+        self.placeholder = placeholder
+        self.value: str = ""
+
+
+class Label(Widget):
+    pass
+
+
+class Select(Widget):
+    def __init__(self, options: Sequence[tuple[str, Any]] | None = None, *children: Any, id: str | None = None, prompt: str | None = None, **kwargs: Any) -> None:  # noqa: D401,E501
+        super().__init__(*children, id=id, **kwargs)
+        self.options = list(options or [])
+        self.prompt = prompt
+        self.value: Any = None
+
+
+class DataTable(Widget):
+    """Very small in-memory table supporting the methods used by tests."""
+
+    def __init__(self, *children: Any, zebra_stripes: bool | None = None, **kwargs: Any) -> None:  # noqa: D401,E501
+        super().__init__(*children, **kwargs)
+        self._columns: list[dict[str, Any]] = []
+        self._rows: list[tuple[list[Any], str | None]] = []
+        self.cursor_type: str | None = None
+        self.cursor_row: str | None = None
+        self._zebra = zebra_stripes
+
+    @property
+    def columns(self) -> list[str]:
+        return [column["title"] for column in self._columns]
+
+    @property
+    def row_count(self) -> int:
+        return len(self._rows)
+
+    def add_column(self, title: str, *, key: str | None = None) -> None:
+        self._columns.append({"title": title, "key": key})
+
+    def clear(self, *, columns: bool = False) -> None:
+        self._rows.clear()
+        if columns:
+            self._columns.clear()
+
+    def add_row(self, *values: Any, key: str | None = None) -> None:
+        self._rows.append((list(values), key))
+        if key is not None:
+            self.cursor_row = key
+
+    def move_cursor(self, *, row: int = 0, column: int = 0) -> None:  # pragma: no cover - noop cursor handling
+        if not self._rows:
+            self.cursor_row = None
+            return
+        index = max(0, min(row, len(self._rows) - 1))
+        _, key = self._rows[index]
+        self.cursor_row = key or str(index)
+
+
+class ModalScreen(Widget):
     """Placeholder that mirrors the Textual API expected in tests."""
+
+    def __init__(self, *children: Any, **kwargs: Any) -> None:  # noqa: D401
+        super().__init__(*children, **kwargs)
+        self._result: Any = None
 
     def compose(self) -> ComposeResult:  # pragma: no cover - not used directly in tests
         return ComposeResult()
+
+    def dismiss(self, result: Any | None = None) -> None:  # pragma: no cover - noop default
+        self._result = result
+
+
+class Reactive:
+    """Simplistic stand-in for :func:`textual.reactive`."""
+
+    def __init__(self, default: Any) -> None:
+        self._default = default
+        self._attr_name: str | None = None
+
+    def __set_name__(self, owner: type, name: str) -> None:  # pragma: no cover - trivial
+        self._attr_name = f"_{name}"
+
+    def __get__(self, instance: Any, owner: type | None = None) -> Any:
+        if instance is None:
+            return self
+        if self._attr_name is None:
+            return self._default
+        return getattr(instance, self._attr_name, self._default)
+
+    def __set__(self, instance: Any, value: Any) -> None:
+        if self._attr_name is None:
+            raise AttributeError("Reactive descriptor misconfigured")
+        setattr(instance, self._attr_name, value)
 
 
 class _TestPilot:
@@ -70,7 +204,8 @@ class App:
     """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: D401
-        pass
+        self._running = False
+        self._screens: list[ModalScreen] = []
 
     def on_mount(self) -> None:  # pragma: no cover - default no-op
         pass
@@ -81,8 +216,28 @@ class App:
     @asynccontextmanager
     async def run_test(self) -> AsyncIterator[_TestPilot]:
         pilot = _TestPilot(self)
+        self._running = True
         self.on_mount()
         try:
             yield pilot
         finally:
             self.on_unmount()
+            self._running = False
+
+    # ------------------------------------------------------------------
+    def notify(self, message: str, *, severity: str = "information") -> None:  # pragma: no cover - trivial logging
+        self.log(f"[{severity}] {message}")
+
+    def log(self, message: str) -> None:  # pragma: no cover - trivial logging
+        self._last_log = message
+
+    def push_screen(self, screen: ModalScreen) -> None:  # pragma: no cover - simple storage
+        screen.app = self
+        self._screens.append(screen)
+
+    async def push_screen_wait(self, screen: ModalScreen) -> Any:
+        self.push_screen(screen)
+        return screen._result
+
+    def exit(self) -> None:  # pragma: no cover - trivial flag
+        self._running = False

--- a/portfolio_tool/app/tui/app.py
+++ b/portfolio_tool/app/tui/app.py
@@ -6,23 +6,18 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-try:  # pragma: no cover - exercised indirectly in tests
-    from textual.app import App, ComposeResult
-    from textual.containers import Container
-    from textual.screen import ModalScreen
-    from textual.widgets import Footer, Header, Static, TabbedContent, TabPane
-except ModuleNotFoundError:  # pragma: no cover - used when textual is optional
-    from ._textual_stub import (  # type: ignore[assignment]
-        App,
-        ComposeResult,
-        Container,
-        Footer,
-        Header,
-        ModalScreen,
-        Static,
-        TabbedContent,
-        TabPane,
-    )
+from ._textual import (
+    HAVE_TEXTUAL,
+    App,
+    ComposeResult,
+    Container,
+    Footer,
+    Header,
+    ModalScreen,
+    Static,
+    TabbedContent,
+    TabPane,
+)
 
 from ...core.config import DEFAULT_CONFIG_PATH, ensure_config, load_config
 from ...core.pricing import PricingService
@@ -102,6 +97,19 @@ class PortfolioApp(App[None]):
         self.actionables_view = ActionablesView()
         self.prices_view = PricesView()
         self.config_view = ConfigView()
+
+        if not HAVE_TEXTUAL:
+            for view in (
+                self.dashboard_view,
+                self.trades_view,
+                self.positions_view,
+                self.lots_view,
+                self.cgt_view,
+                self.actionables_view,
+                self.prices_view,
+                self.config_view,
+            ):
+                view.app = self
 
     # ------------------------------------------------------------------
     def compose(self) -> ComposeResult:

--- a/portfolio_tool/app/tui/views/base.py
+++ b/portfolio_tool/app/tui/views/base.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 
 from typing import Sequence
 
-from textual.app import ComposeResult
-from textual.containers import Horizontal, Vertical
-from textual.reactive import reactive
-from textual.widgets import Input, Static
+from .._textual import ComposeResult, Horizontal, Input, Static, Vertical, reactive
 
 from ..widgets.tables import Loader, PagedTable
 

--- a/portfolio_tool/app/tui/views/dashboard.py
+++ b/portfolio_tool/app/tui/views/dashboard.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from textual.app import ComposeResult
-from textual.widgets import Static
+from .._textual import ComposeResult, Static
 from zoneinfo import ZoneInfo
 
 from .base import PortfolioView

--- a/portfolio_tool/app/tui/widgets/forms.py
+++ b/portfolio_tool/app/tui/widgets/forms.py
@@ -4,10 +4,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Mapping
 
-from textual.app import ComposeResult
-from textual.containers import Grid
-from textual.screen import ModalScreen
-from textual.widgets import Button, Input, Label, Select
+from .._textual import Button, ComposeResult, Grid, Input, Label, ModalScreen, Select
 from zoneinfo import ZoneInfo
 
 TRADE_TYPES = [

--- a/portfolio_tool/app/tui/widgets/tables.py
+++ b/portfolio_tool/app/tui/widgets/tables.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Callable, Sequence
 
-from textual.widgets import DataTable
+from .._textual import DataTable
 
 Loader = Callable[[int, int, str], tuple[Sequence[dict[str, object]], int]]
 

--- a/portfolio_tool/app/tui/widgets/toasts.py
+++ b/portfolio_tool/app/tui/widgets/toasts.py
@@ -1,7 +1,7 @@
 """Toast helpers for the Textual application."""
 from __future__ import annotations
 
-from textual.app import App
+from .._textual import App
 
 
 def show_toast(app: App, message: str, *, severity: str = "information") -> None:


### PR DESCRIPTION
## Summary
- add a compatibility module that imports Textual when available and falls back to local shims
- expand the local Textual shim to cover the widgets used by the TUI
- update TUI modules to use the compatibility imports so the app can start without Textual installed

## Testing
- pytest portfolio_tool/tests/test_tui.py

------
https://chatgpt.com/codex/tasks/task_e_68def9e228fc8322b4e357ccbaabf7f5